### PR TITLE
feat:게시물 등록,삭제 무한스크롤 구현

### DIFF
--- a/src/main/java/com/team_7/moment_film/MomentFilmApplication.java
+++ b/src/main/java/com/team_7/moment_film/MomentFilmApplication.java
@@ -2,10 +2,13 @@ package com.team_7.moment_film;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+
+
 @EnableJpaAuditing
-@SpringBootApplication
+@SpringBootApplication(exclude = SecurityAutoConfiguration.class)
 public class MomentFilmApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/team_7/moment_film/domain/post/S3/config/S3Config.java
+++ b/src/main/java/com/team_7/moment_film/domain/post/S3/config/S3Config.java
@@ -1,0 +1,34 @@
+package com.team_7.moment_film.domain.post.S3.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3Client amazonS3Client() {
+        BasicAWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+
+        return (AmazonS3Client) AmazonS3ClientBuilder
+                .standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .build();
+    }
+}

--- a/src/main/java/com/team_7/moment_film/domain/post/S3/service/S3Service.java
+++ b/src/main/java/com/team_7/moment_film/domain/post/S3/service/S3Service.java
@@ -1,0 +1,152 @@
+package com.team_7.moment_film.domain.post.S3.service;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.AmazonS3Exception;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.team_7.moment_film.domain.post.exception.UploadException;
+import com.team_7.moment_film.global.statuscode.ErrorCodeEnum;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+
+    private final AmazonS3 amazonS3;
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    /**
+     * 이미지를 S3에 업로드하고 업로드된 이미지의 S3 URL을 반환합니다.
+     *
+     * @param multipartFile 업로드할 이미지 파일
+     * @return 업로드된 이미지의 S3 URL
+     * @throws IllegalArgumentException 업로드 실패 시 발생하는 예외
+     */
+    public String upload(MultipartFile multipartFile) {
+        if (multipartFile == null || multipartFile.isEmpty()) return null;
+
+        try {
+            byte[] fileBytes = multipartFile.getBytes();
+            String fileName = generateFileName(multipartFile.getOriginalFilename());
+            String contentType = multipartFile.getContentType();
+            putS3(fileBytes, fileName, contentType);
+            String imageUrl = generateUnsignedUrl(fileName);
+            log.info("이미지 업로드 완료: " + imageUrl);
+            return imageUrl;
+        } catch (IOException e) {
+            throw new UploadException(ErrorCodeEnum.UPLOAD_FAIL, e);
+        }
+    }
+
+
+    /**
+     * 이미지를 S3에 업로드합니다.
+     *
+     * @param fileBytes   업로드할 이미지의 바이트 배열
+     * @param fileName    업로드할 이미지의 파일 이름
+     * @param contentType 업로드할 이미지의 컨텐츠 타입
+     */
+    private void putS3(byte[] fileBytes, String fileName, String contentType) {
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentLength(fileBytes.length);
+        metadata.setContentType(contentType);
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(fileBytes);
+        amazonS3.putObject(new PutObjectRequest(bucket, fileName, inputStream, metadata));
+        log.info("파일 생성: " + fileName);
+    }
+
+    /**
+     * S3에서 이미지를 삭제합니다.
+     *
+     * @param imageUrl 삭제할 이미지의 URL
+     * @throws IllegalArgumentException 이미지 삭제 실패 시 발생하는 예외
+     */
+    public void delete(String imageUrl) {
+        if (StringUtils.hasText(imageUrl)) {
+            String fileName = extractObjectKeyFromUrl(imageUrl);
+            try {
+                String decodedFileName = URLDecoder.decode(fileName, StandardCharsets.UTF_8);
+                if (!amazonS3.doesObjectExist(bucket, decodedFileName)) {
+                    throw new AmazonS3Exception(decodedFileName + " 은 존재하지 않습니다");
+                }
+                amazonS3.deleteObject(bucket, decodedFileName);
+                log.info("파일 삭제: " + decodedFileName);
+            } catch (IllegalArgumentException e) {
+                throw new UploadException(ErrorCodeEnum.FILE_DECODE_FAIL, e);
+            }
+        }
+    }
+
+    /**
+     * 이미지 URL에서 S3 객체 키를 추출합니다.
+     *
+     * @param imageUrl 이미지의 URL
+     * @return 추출된 S3 객체 키
+     * @throws IllegalArgumentException 잘못된 URL 형식일 경우 발생하는 예외
+     */
+    private String extractObjectKeyFromUrl(String imageUrl) {
+        try {
+            URL url = new URL(imageUrl);
+            return url.getPath().substring(1); // leading slash 제거
+        } catch (Exception e) {
+            throw new UploadException(ErrorCodeEnum.URL_INVALID, e);
+        }
+    }
+
+    /**
+     * 업로드할 이미지 파일의 원본 파일 이름으로 고유한 파일 이름을 생성합니다.
+     *
+     * @param originalFilename 업로드할 이미지 파일의 원본 파일 이름
+     * @return 생성된 고유한 파일 이름
+     * @throws IllegalArgumentException 파일 이름이 유효하지 않을 경우 발생하는 예외
+     */
+    private String generateFileName(String originalFilename) {
+        if (StringUtils.hasText(originalFilename)) {
+            String extension = extractExtension(originalFilename);
+            String uniqueId = UUID.randomUUID().toString();
+            return uniqueId + "." + extension;
+        }
+        throw new UploadException(ErrorCodeEnum.FILE_INVALID);
+    }
+
+    /**
+     * 파일 이름에서 확장자를 추출합니다.
+     *
+     * @param originalFilename 파일 이름
+     * @return 추출된 확장자
+     * @throws IllegalArgumentException 확장자를 추출할 수 없을 경우 발생하는 예외
+     */
+    private String extractExtension(String originalFilename) {
+        if (StringUtils.hasText(originalFilename)) {
+            int extensionIndex = originalFilename.lastIndexOf(".");
+            if (extensionIndex != -1) {
+                return originalFilename.substring(extensionIndex + 1);
+            }
+        }
+        throw new UploadException(ErrorCodeEnum.EXTRACT_INVALID);
+    }
+
+    /**
+     * S3 객체에 대한 유효기간이 없는 서명되지 않은 URL을 생성합니다.
+     *
+     * @param objectKey S3 객체 키
+     * @return 유효기간이 없는 서명되지 않은 URL
+     */
+    private String generateUnsignedUrl(String objectKey) {
+        String baseUrl = "https://" + bucket + ".s3.amazonaws.com/";
+        return baseUrl + objectKey;
+    }
+}

--- a/src/main/java/com/team_7/moment_film/domain/post/controller/PostController.java
+++ b/src/main/java/com/team_7/moment_film/domain/post/controller/PostController.java
@@ -1,0 +1,44 @@
+package com.team_7.moment_film.domain.post.controller;
+
+
+import com.team_7.moment_film.domain.post.dto.PostRequestDto;
+import com.team_7.moment_film.domain.post.dto.PostSliceRequest;
+import com.team_7.moment_film.domain.post.dto.PostSliceResponse;
+import com.team_7.moment_film.domain.post.service.PostQueryService;
+import com.team_7.moment_film.domain.post.service.PostService;
+import com.team_7.moment_film.global.dto.CustomResponseEntity;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@RequestMapping("/api/post")
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+public class PostController {
+
+    private final PostService postService;
+    private final PostQueryService postQueryService;
+
+    @PostMapping(value = {""}, consumes = { MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE })
+    public CustomResponseEntity<?> createPost(PostRequestDto requestDto,
+                                              @RequestPart(value = "imageFile", required = false)MultipartFile image
+                                              ){
+        return postService.createPost(requestDto, image);
+    }
+
+    @DeleteMapping("/{postId}")
+    public CustomResponseEntity<?> deletePost(@PathVariable Long postId){
+        return postService.deletePost(postId);
+    }
+
+    // 무한 스크롤 페이징
+    @GetMapping()
+    public CustomResponseEntity<List<PostSliceResponse>> getAll(PostSliceRequest request){
+        return postQueryService.getAll(request);
+    }
+}

--- a/src/main/java/com/team_7/moment_film/domain/post/dto/PostRequestDto.java
+++ b/src/main/java/com/team_7/moment_film/domain/post/dto/PostRequestDto.java
@@ -1,0 +1,18 @@
+package com.team_7.moment_film.domain.post.dto;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public class PostRequestDto {
+    private Long id;
+    private String image;
+    private MultipartFile imageFile;
+
+
+    public PostRequestDto(Long id, String image, MultipartFile imageFile){
+        this.id = id;
+        this.image = image;
+        this.imageFile = imageFile;
+    }
+
+
+}

--- a/src/main/java/com/team_7/moment_film/domain/post/dto/PostResponseDto.java
+++ b/src/main/java/com/team_7/moment_film/domain/post/dto/PostResponseDto.java
@@ -1,0 +1,18 @@
+package com.team_7.moment_film.domain.post.dto;
+
+import com.team_7.moment_film.domain.post.entity.Post;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class PostResponseDto {
+    private Long id;
+    private String image;
+
+
+    public PostResponseDto(Post post){
+        this.id = post.getId();
+        this.image = post.getImage();
+    }
+}

--- a/src/main/java/com/team_7/moment_film/domain/post/dto/PostSliceRequest.java
+++ b/src/main/java/com/team_7/moment_film/domain/post/dto/PostSliceRequest.java
@@ -1,0 +1,20 @@
+package com.team_7.moment_film.domain.post.dto;
+
+import jakarta.annotation.Nullable;
+
+public record PostSliceRequest(
+        @Nullable
+        Long id,
+        Integer size
+) {
+
+    public PostSliceRequest(
+            @Nullable
+            Long id,
+            Integer size
+    ) {
+        this.id = id;
+        this.size = size == null ? 20 : size;
+    }
+
+}

--- a/src/main/java/com/team_7/moment_film/domain/post/dto/PostSliceResponse.java
+++ b/src/main/java/com/team_7/moment_film/domain/post/dto/PostSliceResponse.java
@@ -1,0 +1,14 @@
+package com.team_7.moment_film.domain.post.dto;
+
+import com.team_7.moment_film.domain.post.entity.Post;
+
+public record PostSliceResponse(
+        long id,
+        String image
+) {
+
+    public static PostSliceResponse from(Post post) {
+        return new PostSliceResponse(post.getId(), post.getImage());
+    }
+
+}

--- a/src/main/java/com/team_7/moment_film/domain/post/entity/Post.java
+++ b/src/main/java/com/team_7/moment_film/domain/post/entity/Post.java
@@ -1,0 +1,29 @@
+package com.team_7.moment_film.domain.post.entity;
+
+import com.team_7.moment_film.domain.post.dto.PostRequestDto;
+import com.team_7.moment_film.global.config.TimeStamped;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Post extends TimeStamped {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "post_id")
+    Long id;
+
+    @Column(nullable = false)
+    private String image;
+
+
+    public Post(PostRequestDto requestDto, String image){
+        this.image = image;
+    }
+
+
+
+}

--- a/src/main/java/com/team_7/moment_film/domain/post/exception/UploadException.java
+++ b/src/main/java/com/team_7/moment_film/domain/post/exception/UploadException.java
@@ -1,0 +1,16 @@
+package com.team_7.moment_film.domain.post.exception;
+
+import com.team_7.moment_film.global.statuscode.ErrorCodeEnum;
+
+public class UploadException extends RuntimeException{
+    ErrorCodeEnum errorCodeEnum;
+
+    public UploadException(ErrorCodeEnum errorCodeEnum) {
+        this.errorCodeEnum = errorCodeEnum;
+    }
+
+    public UploadException(ErrorCodeEnum errorCodeEnum, Throwable cause) {
+        super(cause);
+        this.errorCodeEnum = errorCodeEnum;
+    }
+}

--- a/src/main/java/com/team_7/moment_film/domain/post/repository/PostQueryRepository.java
+++ b/src/main/java/com/team_7/moment_film/domain/post/repository/PostQueryRepository.java
@@ -1,0 +1,41 @@
+package com.team_7.moment_film.domain.post.repository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.team_7.moment_film.domain.post.entity.Post;
+import jakarta.annotation.Nullable;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.team_7.moment_film.domain.post.entity.QPost.post;
+
+@Repository
+@RequiredArgsConstructor
+public class PostQueryRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    public List<Post> getSliceOfPost(
+            @Nullable
+            Long id,
+            int size
+    ) {
+        return jpaQueryFactory.selectFrom(post)
+                .where(ltPostId(id))
+                .join(post)
+                .fetchJoin()
+                .where(post.id.eq(post.id))
+                .orderBy(post.id.desc())
+                .limit(size)
+                .fetch();
+
+    }
+
+
+
+    private BooleanExpression ltPostId(@Nullable Long id) {
+        return id == null ? null : post.id.lt(id);
+    }
+}

--- a/src/main/java/com/team_7/moment_film/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/team_7/moment_film/domain/post/repository/PostRepository.java
@@ -1,0 +1,9 @@
+package com.team_7.moment_film.domain.post.repository;
+
+import com.team_7.moment_film.domain.post.entity.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+
+
+}

--- a/src/main/java/com/team_7/moment_film/domain/post/service/PostQueryService.java
+++ b/src/main/java/com/team_7/moment_film/domain/post/service/PostQueryService.java
@@ -1,0 +1,27 @@
+package com.team_7.moment_film.domain.post.service;
+
+import com.team_7.moment_film.domain.post.dto.PostSliceRequest;
+import com.team_7.moment_film.domain.post.dto.PostSliceResponse;
+import com.team_7.moment_film.domain.post.repository.PostQueryRepository;
+import com.team_7.moment_film.global.dto.CustomResponseEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class PostQueryService {
+
+    private final PostQueryRepository postQueryRepository;
+
+
+    // 전체조회(무한스크롤)
+    public CustomResponseEntity<List<PostSliceResponse>> getAll(PostSliceRequest request){
+        return new CustomResponseEntity<>(HttpStatus.OK,"무한스크롤 전체조회",postQueryRepository.getSliceOfPost(request.id(), request.size()).stream()
+                .map(PostSliceResponse::from)
+                .collect(Collectors.toList()));
+    }
+}

--- a/src/main/java/com/team_7/moment_film/domain/post/service/PostService.java
+++ b/src/main/java/com/team_7/moment_film/domain/post/service/PostService.java
@@ -1,0 +1,45 @@
+package com.team_7.moment_film.domain.post.service;
+
+import com.team_7.moment_film.domain.post.S3.service.S3Service;
+import com.team_7.moment_film.domain.post.dto.PostRequestDto;
+import com.team_7.moment_film.domain.post.entity.Post;
+import com.team_7.moment_film.domain.post.repository.PostRepository;
+import com.team_7.moment_film.global.dto.CustomResponseEntity;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PostService {
+
+
+    private final PostRepository postRepository;
+    private final S3Service s3Service;
+
+
+    // 생성
+    public CustomResponseEntity<?> createPost(PostRequestDto requestDto, MultipartFile image) {
+        String imageUrl = s3Service.upload(image);
+        Post savepost = postRepository.save(new Post(requestDto, imageUrl));
+        log.info("생성 중 !", imageUrl, image);
+        return new CustomResponseEntity<>(HttpStatus.CREATED, "생성되었습니다.", savepost);
+    }
+
+    //삭제
+    public CustomResponseEntity<?> deletePost(Long postId) {
+        Post post = postRepository.findById(postId).orElseThrow(() ->
+                new IllegalArgumentException("찾을 수 없습니다."));
+        String imageurl = post.getImage();
+        s3Service.delete(imageurl);
+        postRepository.delete(post);
+        return new CustomResponseEntity<>(HttpStatus.OK, "삭제되었습니다.", post);
+    }
+
+//    public CustomResponseEntity<?> singlePost(Long postId){
+//
+//    }
+}

--- a/src/main/java/com/team_7/moment_film/global/config/QueryDslConfig.java
+++ b/src/main/java/com/team_7/moment_film/global/config/QueryDslConfig.java
@@ -1,0 +1,20 @@
+package com.team_7.moment_film.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}
+

--- a/src/main/resources/application-secret.properties
+++ b/src/main/resources/application-secret.properties
@@ -1,14 +1,14 @@
 # ?? MYSQL DB ??
-spring.datasource.url=jdbc:mysql://localhost:3306/?? ??? ?????!
+spring.datasource.url=jdbc:mysql://localhost:3306/post
 spring.datasource.username=root
-spring.datasource.password={password}
+spring.datasource.password=tngkr156123!
 
 # AWS S3
-#cloud.aws.credentials.accessKey=
-#cloud.aws.credentials.secretKey=q
-#cloud.aws.s3.bucket=
-#cloud.aws.region.static=
-#cloud.aws.stack.auto-=false
+cloud.aws.credentials.accessKey=AKIA6JYPWFVD6Y4AX6HI
+cloud.aws.credentials.secretKey=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
+cloud.aws.s3.bucket=momentfilm
+cloud.aws.region.static=ap-northeast-2
+cloud.aws.stack.auto-=false
 
 # JWT
 #jwt.secret.key=


### PR DESCRIPTION
게시물 등록,삭제 (단순히 생성과 삭제만 할 수 있도록 만들었습니다.)
무한 스크롤 QueryDSL을 이용해서 구현
Global config에 QueryDslconfig 추가

User 추가시 권한 추가 예정 

아직 계정없이 test하실 수 있습니다.