### PR TITLE
Feat : Redis를 적용하여 JWT 토큰 관리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,8 @@ repositories {
 }
 
 dependencies {
+	// Redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	// java 8이상의 날짜 시간
 	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 	//Mapper

--- a/src/main/java/com/team_7/moment_film/domain/user/service/KakaoService.java
+++ b/src/main/java/com/team_7/moment_film/domain/user/service/KakaoService.java
@@ -6,7 +6,7 @@ import com.team_7.moment_film.domain.user.dto.KakaoUserInfoDto;
 import com.team_7.moment_film.domain.user.entity.User;
 import com.team_7.moment_film.domain.user.repository.UserRepository;
 import com.team_7.moment_film.global.dto.CustomResponseEntity;
-import com.team_7.moment_film.global.jwt.JwtUtil;
+import com.team_7.moment_film.global.util.JwtUtil;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/team_7/moment_film/global/config/RedisConfig.java
+++ b/src/main/java/com/team_7/moment_film/global/config/RedisConfig.java
@@ -1,0 +1,35 @@
+package com.team_7.moment_film.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableRedisRepositories
+public class RedisConfig {
+    // Redis 에 설정된 값을 가진 객체를 주입받음
+    private final RedisProperties redisProperties;
+
+    // RedisConnectionFactory 인터페이스를 implement 하는 LettuceConnectionFactory(host, port) 를 생성하여 반환
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(redisProperties.getHost(), redisProperties.getPort());
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>(); // RedisTemplate 생성
+        redisTemplate.setConnectionFactory(redisConnectionFactory()); // RedisConnectionFactory 와 연결
+        // // redis-cli 을 통해 직접 데이터를 조회 시 알아볼 수 없는 형태로 출력되는 것을 방지
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/team_7/moment_film/global/config/SecurityConfig.java
+++ b/src/main/java/com/team_7/moment_film/global/config/SecurityConfig.java
@@ -2,8 +2,9 @@ package com.team_7.moment_film.global.config;
 
 import com.team_7.moment_film.global.filter.JwtAuthenticationFilter;
 import com.team_7.moment_film.global.filter.JwtAuthorizationFilter;
-import com.team_7.moment_film.global.jwt.JwtUtil;
+import com.team_7.moment_film.global.util.JwtUtil;
 import com.team_7.moment_film.global.security.UserDetailsServiceImpl;
+import com.team_7.moment_film.global.util.RedisUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
@@ -19,13 +20,13 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 import static org.springframework.http.HttpMethod.GET;
-import static org.springframework.http.HttpMethod.POST;
 
 @Configuration
 @EnableWebSecurity // spring security 지원을 가능하게 함.
 @RequiredArgsConstructor
 public class SecurityConfig {
     private final JwtUtil jwtUtil;
+    private final RedisUtil redisUtil;
     private final UserDetailsServiceImpl userDetailsService;
     private final AuthenticationConfiguration authenticationConfiguration;
 
@@ -45,7 +46,7 @@ public class SecurityConfig {
     // 위에서 만든 AuthenticationManager 생성 메서드를 호출 후 반환된 Authentication 을 filter 에 세팅
     @Bean
     public JwtAuthenticationFilter jwtAuthenticationFilter() throws Exception {
-        JwtAuthenticationFilter filter = new JwtAuthenticationFilter(jwtUtil);
+        JwtAuthenticationFilter filter = new JwtAuthenticationFilter(jwtUtil, redisUtil);
         filter.setAuthenticationManager(authenticationManager(authenticationConfiguration));
         return filter;
     }

--- a/src/main/java/com/team_7/moment_film/global/config/SecurityConfig.java
+++ b/src/main/java/com/team_7/moment_film/global/config/SecurityConfig.java
@@ -54,7 +54,7 @@ public class SecurityConfig {
     // JwtAuthorizationFilter에 필요한 JwtUtil, userDetailsService 객체 주입하여 필터 생성
     @Bean
     public JwtAuthorizationFilter jwtAuthorizationFilter() throws Exception {
-        return new JwtAuthorizationFilter(jwtUtil, userDetailsService);
+        return new JwtAuthorizationFilter(jwtUtil, redisUtil, userDetailsService);
     }
 
     // 위에서 만든 Filter 의 순서와 인증 및 인가를 설정

--- a/src/main/java/com/team_7/moment_film/global/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/team_7/moment_film/global/filter/JwtAuthenticationFilter.java
@@ -15,6 +15,7 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 import java.io.IOException;
+import java.util.Date;
 
 @Slf4j(topic = "JWT 생성 및 인증 필터")
 public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilter {
@@ -66,7 +67,7 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
 
         // redis에 refreshToken 저장
         String refreshTokenValue = jwtUtil.substringToken(refreshToken);
-        Long expiration = jwtUtil.getUserInfoFromToken(refreshTokenValue).getExpiration().getTime();
+        Date expiration = jwtUtil.getUserInfoFromToken(refreshTokenValue).getExpiration();
         redisUtil.setData(username, refreshTokenValue, expiration);
         log.info("Redis에 RefreshToken 저장");
 

--- a/src/main/java/com/team_7/moment_film/global/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/com/team_7/moment_film/global/filter/JwtAuthorizationFilter.java
@@ -1,6 +1,6 @@
 package com.team_7.moment_film.global.filter;
 
-import com.team_7.moment_film.global.jwt.JwtUtil;
+import com.team_7.moment_film.global.util.JwtUtil;
 import com.team_7.moment_film.global.security.UserDetailsServiceImpl;
 import io.jsonwebtoken.Claims;
 import jakarta.servlet.FilterChain;

--- a/src/main/java/com/team_7/moment_film/global/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/com/team_7/moment_film/global/filter/JwtAuthorizationFilter.java
@@ -32,18 +32,19 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest req, HttpServletResponse res, FilterChain filterChain) throws ServletException, IOException {
         String accessToken = req.getHeader("accessToken");
 
+        // accessToken 토큰 값이 없을 경우 비로그인 사용자, 다음 필터(Authentication)로 이동
         if (StringUtils.hasText(accessToken)) {
             accessToken = jwtUtil.substringToken(accessToken);
 
             // accessToken 검증 실패 시 refreshToken 을 통해 accessToken 재발급 진행
             if (!jwtUtil.validateToken(accessToken)) {
-                log.warn("Token Error, accessToken 검증 실패! refreshToken 으로 JWT 재발급 시도");
+                log.warn("Token Error, accessToken 검증 실패! refreshToken 으로 accessToken 재발급 시도");
                 String refreshToken = jwtUtil.getRefreshToken(req.getHeader("refreshToken"));
 
                 if (StringUtils.hasText(refreshToken) && jwtUtil.validateToken(refreshToken)) {
                     // 최초 로그인 시 redis 에 저장한 refreshToken 을 대조
                     Claims userInfo = jwtUtil.getUserInfoFromToken(refreshToken);
-                    log.info("제출한 refresh 토큰 검증 성공, refreshToken 으로 Claims 조회");
+                    log.info("제출한 refresh 토큰 검증 성공, refreshToken 으로 Claims(사용자 정보) 조회");
 
                     Long userId = Long.valueOf(userInfo.getSubject());
                     String email = userInfo.get("email").toString();
@@ -52,35 +53,27 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
                     String redisRefreshToken = redisUtil.getData(username);
                     log.info("redis 에서 기존에 저장된 refreshToken 불러오기 성공");
 
-                    // redis 에서 가져온 refreshToken 이 유효하고, 제출한 refreshToken 과 일치한 경우 새 accessToken, refreshToken 재발급
+                    // redis 에서 가져온 refreshToken 이 유효하고, 제출한 refreshToken 과 일치한 경우 새 accessToken 재발급
                     if (StringUtils.hasText(redisRefreshToken) && refreshToken.equals(redisRefreshToken)) {
+                        log.info("refreshToken 검증 완료");
                         String accessTokenWithBearer = jwtUtil.createAccessToken(userId, username, email);
                         accessToken = jwtUtil.substringToken(accessTokenWithBearer);
-                        refreshToken = jwtUtil.createRefreshToken(userId, username, email);
-                        log.info("accessToken, refreshToken 재발급 성공");
-
-                        String refreshTokenValue = jwtUtil.substringToken(refreshToken);
-                        Date expiration = jwtUtil.getUserInfoFromToken(refreshTokenValue).getExpiration();
-
-                        // redis 에 refreshToken 값 덮어쓰기
-                        redisUtil.setData(username, refreshTokenValue, expiration);
-                        log.info("redis에 새로 발급한 refreshToken 저장");
+                        log.info("accessToken 재발급 성공");
 
                         res.setHeader("accessToken", accessTokenWithBearer);
-                        res.setHeader("refreshToken", refreshToken);
-                        log.info("헤더에 새로 발급한 ACT, RFT 저장");
+                        log.info("헤더에 새로 발급한 AccessToken 저장");
                     }
                 } else {
-                    // accessToken 검증 실패 후 refreshToken의 형식이 올바르지 않거나, 만료되었을 경우
-                    log.error("올바르지 않은 Token 형식이거나, refreshToken 만료됨. 다시 로그인을 해주세요.");
+                    // accessToken 검증 실패 후 제출한 refreshToken 의 형식이 올바르지 않거나, redis 의 refreshToken 이 만료되었을 경우
+                    log.error("올바르지 않은 refreshToken 형식이거나, refreshToken이 만료되었습니다. 다시 로그인을 해주세요.");
                     return;
                 }
             }
 
             try {
                 Claims info = jwtUtil.getUserInfoFromToken(accessToken);
-                log.info("Create Authentication, 인증 객체 생성 및 SecurityContextHolder 저장 성공");
                 setAuthentication((String) info.get("email"));
+                log.info("Create Authentication, 인증 객체 생성 및 SecurityContextHolder 저장 성공");
             } catch (Exception e) {
                 // 인증 객체를 생성할 수 없는 경우
                 log.error("Failed to create Authentication : " + e.getMessage());

--- a/src/main/java/com/team_7/moment_film/global/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/com/team_7/moment_film/global/filter/JwtAuthorizationFilter.java
@@ -1,7 +1,8 @@
 package com.team_7.moment_film.global.filter;
 
-import com.team_7.moment_film.global.util.JwtUtil;
 import com.team_7.moment_film.global.security.UserDetailsServiceImpl;
+import com.team_7.moment_film.global.util.JwtUtil;
+import com.team_7.moment_film.global.util.RedisUtil;
 import io.jsonwebtoken.Claims;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -18,11 +19,13 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.Date;
 
 @Slf4j(topic = "JWT 검증 및 인가 필터")
 @RequiredArgsConstructor
 public class JwtAuthorizationFilter extends OncePerRequestFilter {
     private final JwtUtil jwtUtil;
+    private final RedisUtil redisUtil;
     private final UserDetailsServiceImpl userDetailsService;
 
     @Override
@@ -32,22 +35,59 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
         if (StringUtils.hasText(accessToken)) {
             accessToken = jwtUtil.substringToken(accessToken);
 
+            // accessToken 검증 실패 시 refreshToken 을 통해 accessToken 재발급 진행
             if (!jwtUtil.validateToken(accessToken)) {
-                log.error("Token Error, JWT 검증 실패!");
-                return;
+                log.warn("Token Error, accessToken 검증 실패! refreshToken 으로 JWT 재발급 시도");
+                String refreshToken = jwtUtil.getRefreshToken(req.getHeader("refreshToken"));
+
+                if (StringUtils.hasText(refreshToken) && jwtUtil.validateToken(refreshToken)) {
+                    // 최초 로그인 시 redis 에 저장한 refreshToken 을 대조
+                    Claims userInfo = jwtUtil.getUserInfoFromToken(refreshToken);
+                    log.info("제출한 refresh 토큰 검증 성공, refreshToken 으로 Claims 조회");
+
+                    Long userId = Long.valueOf(userInfo.getSubject());
+                    String email = userInfo.get("email").toString();
+                    String username = userInfo.get("username").toString();
+
+                    String redisRefreshToken = redisUtil.getData(username);
+                    log.info("redis 에서 기존에 저장된 refreshToken 불러오기 성공");
+
+                    // redis 에서 가져온 refreshToken 이 유효하고, 제출한 refreshToken 과 일치한 경우 새 accessToken, refreshToken 재발급
+                    if (StringUtils.hasText(redisRefreshToken) && refreshToken.equals(redisRefreshToken)) {
+                        String accessTokenWithBearer = jwtUtil.createAccessToken(userId, username, email);
+                        accessToken = jwtUtil.substringToken(accessTokenWithBearer);
+                        refreshToken = jwtUtil.createRefreshToken(userId, username, email);
+                        log.info("accessToken, refreshToken 재발급 성공");
+
+                        String refreshTokenValue = jwtUtil.substringToken(refreshToken);
+                        Date expiration = jwtUtil.getUserInfoFromToken(refreshTokenValue).getExpiration();
+
+                        // redis 에 refreshToken 값 덮어쓰기
+                        redisUtil.setData(username, refreshTokenValue, expiration);
+                        log.info("redis에 새로 발급한 refreshToken 저장");
+
+                        res.setHeader("accessToken", accessTokenWithBearer);
+                        res.setHeader("refreshToken", refreshToken);
+                        log.info("헤더에 새로 발급한 ACT, RFT 저장");
+                    }
+                } else {
+                    // accessToken 검증 실패 후 refreshToken의 형식이 올바르지 않거나, 만료되었을 경우
+                    log.error("올바르지 않은 Token 형식이거나, refreshToken 만료됨. 다시 로그인을 해주세요.");
+                    return;
+                }
             }
 
-            Claims info = jwtUtil.getUserInfoFromToken(accessToken);
-
-
             try {
+                Claims info = jwtUtil.getUserInfoFromToken(accessToken);
+                log.info("Create Authentication, 인증 객체 생성 및 SecurityContextHolder 저장 성공");
                 setAuthentication((String) info.get("email"));
             } catch (Exception e) {
-                log.error(e.getMessage());
+                // 인증 객체를 생성할 수 없는 경우
+                log.error("Failed to create Authentication : " + e.getMessage());
                 return;
             }
         }
-
+        // Authentication 필터로 이동
         filterChain.doFilter(req, res);
     }
 

--- a/src/main/java/com/team_7/moment_film/global/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/com/team_7/moment_film/global/filter/JwtAuthorizationFilter.java
@@ -66,6 +66,10 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
                 } else {
                     // accessToken 검증 실패 후 제출한 refreshToken 의 형식이 올바르지 않거나, redis 의 refreshToken 이 만료되었을 경우
                     log.error("올바르지 않은 refreshToken 형식이거나, refreshToken이 만료되었습니다. 다시 로그인을 해주세요.");
+                    res.setCharacterEncoding("UTF-8");
+                    res.setContentType("application/json");
+                    res.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                    res.getWriter().write("올바르지 않은 refreshToken 형식이거나, refreshToken이 만료되었습니다. 다시 로그인을 해주세요.");
                     return;
                 }
             }

--- a/src/main/java/com/team_7/moment_film/global/util/JwtUtil.java
+++ b/src/main/java/com/team_7/moment_film/global/util/JwtUtil.java
@@ -1,4 +1,4 @@
-package com.team_7.moment_film.global.jwt;
+package com.team_7.moment_film.global.util;
 
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;

--- a/src/main/java/com/team_7/moment_film/global/util/JwtUtil.java
+++ b/src/main/java/com/team_7/moment_film/global/util/JwtUtil.java
@@ -19,8 +19,10 @@ public class JwtUtil {
     public static final String HEADER_ACCESS_TOKEN = "accessToken";
     public static final String HEADER_REFRESH_TOKEN = "refreshToken";
     public static final String BEARER_PREFIX = "Bearer ";
-    private final Long ACCESS_TOKEN_EXPIRATION = 6 * 60 * 60 * 1000L; // 6시간
-    private final Long REFRESH_TOKEN_EXPIRATION = 12 * 60 * 60 * 1000L; // 12시간
+    //    private final Long ACCESS_TOKEN_EXPIRATION = 6 * 60 * 60 * 1000L; // 6시간
+//    private final Long REFRESH_TOKEN_EXPIRATION = 12 * 60 * 60 * 1000L; // 12시간
+    private final Long ACCESS_TOKEN_EXPIRATION = 60_000L; // 1분
+    private final Long REFRESH_TOKEN_EXPIRATION = 180_000L; // 3분
 
     @Value("${jwt.secret.key}")
     private String secretKey;
@@ -78,22 +80,22 @@ public class JwtUtil {
             Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
             return true;
         } catch (SecurityException e) {
-            log.error("JWT token validation failed, JWT 토큰 유효성 검증에 실패했습니다.");
+            log.warn("JWT token validation failed, JWT 토큰 유효성 검증에 실패했습니다.");
 //            throw new SecurityException("JWT token validation failed, JWT 토큰 유효성 검증에 실패했습니다.");
         } catch (ExpiredJwtException e) {
-            log.error("Expired JWT token, 토큰의 유효 기간이 만료되었습니다.");
+            log.warn("Expired JWT token, 토큰의 유효 기간이 만료되었습니다.");
 //            throw new ExpiredJwtException(null, null,"Expired JWT token, 토큰의 유효 기간이 만료되었습니다.");
         } catch (UnsupportedJwtException e) {
-            log.error("Unsupported JWT token, 지원되지 않는 JWT 토큰입니다.");
+            log.warn("Unsupported JWT token, 지원되지 않는 JWT 토큰입니다.");
 //            throw new UnsupportedJwtException("Unsupported JWT token, 지원되지 않는 JWT 토큰입니다.");
         } catch (IllegalArgumentException e) {
-            log.error("JWT claims is empty, 잘못된 JWT 토큰입니다.");
+            log.warn("JWT claims is empty, 잘못된 JWT 토큰입니다.");
 //            throw new IllegalArgumentException("JWT claims is empty, 잘못된 JWT 토큰입니다.");
         } catch (MalformedJwtException e) {
-            log.error("Invalid JWT token, 유효하지 않은 JWT 토큰 형식입니다.");
+            log.warn("Invalid JWT token, 유효하지 않은 JWT 토큰 형식입니다.");
 //            throw new MalformedJwtException("Invalid JWT token, 유효하지 않은 JWT 토큰 형식입니다.");
         } catch (SignatureException e) {
-            log.error("Invalid JWT signature, 유효하지 않은 JWT 서명입니다.");
+            log.warn("Invalid JWT signature, 유효하지 않은 JWT 서명입니다.");
 //            throw new SignatureException("Invalid JWT signature, 유효하지 않은 JWT 서명입니다.");
         }
         return false;
@@ -102,5 +104,13 @@ public class JwtUtil {
     // JWT의 사용자 정보 가져오는 메서드
     public Claims getUserInfoFromToken(String token) {
         return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody();
+    }
+
+    // refreshToken 가져오는 메서드
+    public String getRefreshToken(String refreshToken) {
+        if (StringUtils.hasText(refreshToken)) {
+            return substringToken(refreshToken);
+        }
+        return null;
     }
 }

--- a/src/main/java/com/team_7/moment_film/global/util/RedisUtil.java
+++ b/src/main/java/com/team_7/moment_film/global/util/RedisUtil.java
@@ -4,7 +4,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 
-import java.util.concurrent.TimeUnit;
+import java.time.Duration;
+import java.util.Date;
 
 @RequiredArgsConstructor
 @Component
@@ -12,8 +13,10 @@ public class RedisUtil {
     private final RedisTemplate<String, Object> redisTemplate;
 
     // redis 데이터 저장 메서드 (key : username, val: refreshToken, expiredTime : TTL)
-    public void setData(String key, String val, Long expiredTime){
-        redisTemplate.opsForValue().set(key, val, expiredTime, TimeUnit.MILLISECONDS);
+    public void setData(String key, String val, Date expiredTime) {
+        long expirationInSeconds = (expiredTime.getTime() - System.currentTimeMillis()) / 1000;
+        Duration duration = Duration.ofSeconds(expirationInSeconds);
+        redisTemplate.opsForValue().set(key, val, duration);
     }
 
     // redis 데이터 조회 메서드

--- a/src/main/java/com/team_7/moment_film/global/util/RedisUtil.java
+++ b/src/main/java/com/team_7/moment_film/global/util/RedisUtil.java
@@ -1,0 +1,28 @@
+package com.team_7.moment_film.global.util;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+
+@RequiredArgsConstructor
+@Component
+public class RedisUtil {
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    // redis 데이터 저장 메서드 (key : username, val: refreshToken, expiredTime : TTL)
+    public void setData(String key, String val, Long expiredTime){
+        redisTemplate.opsForValue().set(key, val, expiredTime, TimeUnit.MILLISECONDS);
+    }
+
+    // redis 데이터 조회 메서드
+    public String getData(String key) {
+        return redisTemplate.opsForValue().get(key).toString();
+    }
+
+    // redis 데이터 삭제 메서드
+    public void deleteData(String key) {
+        redisTemplate.delete(key);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,7 +9,10 @@ spring.jpa.properties.hibernate.show_sql=true
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.properties.hibernate.use_sql_comments=true
 
-
+# Resdis ?? ??
+spring.cache.type=redis
+spring.data.redis.host=localhost
+spring.data.redis.port=6379
 
 spring.jackson.serialization.write_dates_as_timestamps=false
 spring.jpa.generate-ddl=true


### PR DESCRIPTION
- 최초 로그인 시 Redis에 refreshToken 저장 (key : username, value : refreshToken(no Bearer), expiration : refreshToken의 만료 기간)
- 인증이 필요한 API에 접근 시 accessToken이 만료되었을 경우 함께 제출한 refreshToken 검증
- 검증이 완료된 refreshToken으로 redis에 저장된 최초 refreshToken과 일치할 경우 accessToken 재발행 후 header에 담아 클라이언트에게 전달
- 클라이언트가 만료된 refreshToken을 제출할 경우 UnAuthorized(401) StatusCode와 메세지 반환