### PR TITLE
fix : SecurityFilterChain에서 인증/인가 exception 발생 시 예외처리

### DIFF
--- a/src/main/java/com/team_7/moment_film/global/config/SecurityConfig.java
+++ b/src/main/java/com/team_7/moment_film/global/config/SecurityConfig.java
@@ -2,8 +2,10 @@ package com.team_7.moment_film.global.config;
 
 import com.team_7.moment_film.global.filter.JwtAuthenticationFilter;
 import com.team_7.moment_film.global.filter.JwtAuthorizationFilter;
-import com.team_7.moment_film.global.util.JwtUtil;
+import com.team_7.moment_film.global.handler.CustomAccessDeniedHandler;
+import com.team_7.moment_film.global.handler.CustomAuthenticationEntryPoint;
 import com.team_7.moment_film.global.security.UserDetailsServiceImpl;
+import com.team_7.moment_film.global.util.JwtUtil;
 import com.team_7.moment_film.global.util.RedisUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
@@ -29,6 +31,8 @@ public class SecurityConfig {
     private final RedisUtil redisUtil;
     private final UserDetailsServiceImpl userDetailsService;
     private final AuthenticationConfiguration authenticationConfiguration;
+    private final CustomAccessDeniedHandler customAccessDeniedHandler;
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -82,6 +86,13 @@ public class SecurityConfig {
                         .requestMatchers(GET, "/api/filter").permitAll()
                         .requestMatchers(GET, "/api/frame").permitAll()
                         .anyRequest().authenticated()
+        );
+
+        // 예외처리
+        http.exceptionHandling(exceptionHandling ->
+                exceptionHandling
+                        .accessDeniedHandler(customAccessDeniedHandler)
+                        .authenticationEntryPoint(customAuthenticationEntryPoint)
         );
 
         // 필터 순서 (인가 -> 인증)

--- a/src/main/java/com/team_7/moment_film/global/handler/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/team_7/moment_film/global/handler/CustomAccessDeniedHandler.java
@@ -1,0 +1,21 @@
+package com.team_7.moment_film.global.handler;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException exception) throws IOException, ServletException {
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.getWriter().write("접근 권한이 없습니다.");
+    }
+}

--- a/src/main/java/com/team_7/moment_film/global/handler/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/team_7/moment_film/global/handler/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,21 @@
+package com.team_7.moment_film.global.handler;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.getWriter().write("로그인이 필요합니다.");
+    }
+}

--- a/src/main/java/com/team_7/moment_film/global/util/JwtUtil.java
+++ b/src/main/java/com/team_7/moment_film/global/util/JwtUtil.java
@@ -19,10 +19,10 @@ public class JwtUtil {
     public static final String HEADER_ACCESS_TOKEN = "accessToken";
     public static final String HEADER_REFRESH_TOKEN = "refreshToken";
     public static final String BEARER_PREFIX = "Bearer ";
-    //    private final Long ACCESS_TOKEN_EXPIRATION = 6 * 60 * 60 * 1000L; // 6시간
-//    private final Long REFRESH_TOKEN_EXPIRATION = 12 * 60 * 60 * 1000L; // 12시간
-    private final Long ACCESS_TOKEN_EXPIRATION = 60_000L; // 1분
-    private final Long REFRESH_TOKEN_EXPIRATION = 180_000L; // 3분
+    private final Long ACCESS_TOKEN_EXPIRATION = 6 * 60 * 60 * 1000L; // 6시간
+    private final Long REFRESH_TOKEN_EXPIRATION = 12 * 60 * 60 * 1000L; // 12시간
+//    private final Long ACCESS_TOKEN_EXPIRATION = 60_000L; // 1분
+//    private final Long REFRESH_TOKEN_EXPIRATION = 180_000L; // 3분
 
     @Value("${jwt.secret.key}")
     private String secretKey;


### PR DESCRIPTION
- 기존 : 필터에서 인증/인가 exception 발생 시 status code만 전달됨
- 변경 : 필터에서 인증/인가 exception 발생 시 status code와 body에 msg가 함께 전달되도록 수정
- Security Config의 SecurityFilterChain에 exceptionHandling 추가
- global.hanlder package에 CustomAccessDeniedHandler, CustomAuthenticationEntryPoint 추가