### PR TITLE
Feat : 로그아웃 API 추가

### DIFF
--- a/src/main/java/com/team_7/moment_film/global/config/SecurityConfig.java
+++ b/src/main/java/com/team_7/moment_film/global/config/SecurityConfig.java
@@ -2,9 +2,11 @@ package com.team_7.moment_film.global.config;
 
 import com.team_7.moment_film.global.filter.JwtAuthenticationFilter;
 import com.team_7.moment_film.global.filter.JwtAuthorizationFilter;
-import com.team_7.moment_film.global.util.JwtUtil;
+import com.team_7.moment_film.global.filter.JwtLogoutFilter;
 import com.team_7.moment_film.global.security.UserDetailsServiceImpl;
+import com.team_7.moment_film.global.util.JwtUtil;
 import com.team_7.moment_film.global.util.RedisUtil;
+import jakarta.servlet.ServletException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
@@ -18,6 +20,8 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import java.io.IOException;
 
 import static org.springframework.http.HttpMethod.GET;
 
@@ -57,6 +61,11 @@ public class SecurityConfig {
         return new JwtAuthorizationFilter(jwtUtil, redisUtil, userDetailsService);
     }
 
+    @Bean
+    public JwtLogoutFilter jwtLogoutFilter() throws ServletException, IOException {
+        return new JwtLogoutFilter(jwtUtil, redisUtil);
+    }
+
     // 위에서 만든 Filter 의 순서와 인증 및 인가를 설정
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -85,6 +94,7 @@ public class SecurityConfig {
         );
 
         // 필터 순서 (인가 -> 인증)
+        http.addFilterBefore(jwtLogoutFilter(), JwtAuthenticationFilter.class);
         http.addFilterBefore(jwtAuthorizationFilter(), JwtAuthenticationFilter.class);
         http.addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
 

--- a/src/main/java/com/team_7/moment_film/global/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/team_7/moment_film/global/filter/JwtAuthenticationFilter.java
@@ -34,6 +34,7 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
     @Override
     public Authentication attemptAuthentication(HttpServletRequest req, HttpServletResponse res) throws AuthenticationException {
         try {
+            log.info("Authentication 객체 생성 시도");
             // 사용자 전송 data DTO 객체로 Mapping
             LoginRequestDto requestDto = new ObjectMapper().readValue(req.getInputStream(), LoginRequestDto.class);
 

--- a/src/main/java/com/team_7/moment_film/global/filter/JwtLogoutFilter.java
+++ b/src/main/java/com/team_7/moment_film/global/filter/JwtLogoutFilter.java
@@ -1,0 +1,79 @@
+package com.team_7.moment_film.global.filter;
+
+import com.team_7.moment_film.global.util.JwtUtil;
+import com.team_7.moment_film.global.util.RedisUtil;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Date;
+
+@Slf4j(topic = "로그아웃 필터")
+@RequiredArgsConstructor
+public class JwtLogoutFilter extends OncePerRequestFilter {
+    private final JwtUtil jwtUtil;
+    private final RedisUtil redisUtil;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        if (request.getRequestURI().equals("/api/user/logout")) {
+            String accessToken = jwtUtil.substringToken(request.getHeader("accessToken"));
+            String refreshToken = jwtUtil.substringToken(request.getHeader("refreshToken"));
+            // AccessToken, RefreshToken 유효성 확인 및 검증
+            if (!jwtUtil.validateToken(accessToken) && !jwtUtil.validateToken(refreshToken)) {
+                // 토큰 검증 실패한 경우
+                log.error("로그아웃 실패, 유효하지 않은 토큰입니다.");
+                responseHandler(response, "로그아웃 실패, 유효하지 않은 토큰입니다.");
+                return;
+            }
+
+            String username = jwtUtil.getUserInfoFromToken(refreshToken).get("username").toString();
+            if (redisUtil.getData(username) == null) {
+                // redis에 저장된 refreshToken이 없는 경우 -> 만료된 사용자
+                log.error("로그아웃 실패, 이미 만료된 사용자입니다.");
+                responseHandler(response, "로그아웃 실패, 이미 만료된 사용자입니다.");
+                return;
+            }
+            redisUtil.deleteData(username);
+            log.info("Redis에 저장된 RefreshToken 삭제");
+
+            // Redis에 key : AccessToken, value : logout, expire : AccessToken의 남은 만료 시간을 저장 -> 블랙리스트 추가하여 해당 시간동안 토큰 못쓰게 막음
+            Date accessTokenExpiration = jwtUtil.getUserInfoFromToken(accessToken).getExpiration();
+            redisUtil.setData(accessToken, "logout", accessTokenExpiration);
+            log.info("해당 AccessToken을 남은 유효기간 동안 Redis에 저장");
+            // SecurityContextHolder에 setting한 사용자 정보를 비움
+            SecurityContextHolder.clearContext();
+
+            // logout response 반환
+            response.setStatus(HttpServletResponse.SC_OK);
+            response.setContentType("application/json");
+            response.setCharacterEncoding("UTF-8");
+            response.getWriter().write("로그아웃 성공");
+            return;
+        }
+
+        // 로그아웃 요청이 아니면 바로 다음 필터로
+        filterChain.doFilter(request, response);
+    }
+
+    private void responseHandler(HttpServletResponse response, String msg) throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(msg);
+    }
+}
+
+
+
+
+
+
+
+

--- a/src/main/java/com/team_7/moment_film/global/util/RedisUtil.java
+++ b/src/main/java/com/team_7/moment_film/global/util/RedisUtil.java
@@ -21,8 +21,14 @@ public class RedisUtil {
 
     // redis 데이터 조회 메서드
     public String getData(String key) {
-        return redisTemplate.opsForValue().get(key).toString();
+        return (String) redisTemplate.opsForValue().get(key);
     }
+
+    // 해당 key값을 AccessToken이 있는지 조회하는 메서드
+    public boolean checkData(String key) {
+        return redisTemplate.hasKey(key);
+    }
+
 
     // redis 데이터 삭제 메서드
     public void deleteData(String key) {


### PR DESCRIPTION
- 로그아웃 필터 추가하여 가장 먼저 실행되도록 설정
- 로그아웃 시도할 때 최초 로그인 시 Redis에 저장했던 refreshToken 제거
- 로그아웃 시도할 때 제출한 AccessToken의 남은 유효기간 동안 Redis에 저장
   (key : accessToken, value : logout, expire : AccessToken의 남은 만료 기간)
- 로그아웃 후 해당 accessToken으로 로그인이 필요한 url 접근 시 status 401 return

