### PR TITLE
Fix : 게시글이 존재하는 프로필 조회 시 500 Internal Server Error 문제 임시 해결 

### DIFF
--- a/src/main/java/com/team_7/moment_film/domain/comment/entity/Comment.java
+++ b/src/main/java/com/team_7/moment_film/domain/comment/entity/Comment.java
@@ -47,8 +47,11 @@ public class Comment extends TimeStamped{
     @JoinColumn(name = "users_id")
     private User writer;
 
+    // Post Entity에서 subComments가 Post Entity 대상으로 orphanRemoval 옵션이 걸려져 있는데 여기서 한 번 더 거는 이유?
     @OneToMany(mappedBy = "comment", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<SubComment> subComments = new ArrayList<>();
+
+    // Builder pattern과 생성자 pattern을 혼용해서 사용하는 이유?
     @Builder
     public Comment(Long id, String content, boolean isDeleted, Post post, User writer, String username, Long userId){
         this.id = id;
@@ -59,9 +62,11 @@ public class Comment extends TimeStamped{
         this.userId = userId;
     }
 
+    // @Getter가 달려있는데 Get 메서드가 필요한 이유?
     public List<SubComment> getSubComments() {
         return subComments;
     }
+    // Set메서드가 필요한 이유?
     public void setSubComments(List<SubComment> subComments) {
         this.subComments = subComments;
     }

--- a/src/main/java/com/team_7/moment_film/domain/comment/entity/SubComment.java
+++ b/src/main/java/com/team_7/moment_film/domain/comment/entity/SubComment.java
@@ -14,6 +14,7 @@ import static jakarta.persistence.FetchType.LAZY;
 
 
 @NoArgsConstructor
+@AllArgsConstructor
 @Builder
 @Getter
 @Entity
@@ -27,10 +28,11 @@ public class SubComment extends TimeStamped {
     private Comment comment;
 
 
-    @Lob
+    @Lob // 대용량 데이터를 처리하는 @Lob이 꼭 필요할까?
     @Column
     private String content;
 
+    // 대댓글에서 게시글을 참조하는 이유?
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id") // 수정: post_id로 변경
     private Post post; // 수정: Post 타입으로 변경
@@ -39,9 +41,9 @@ public class SubComment extends TimeStamped {
     @JoinColumn(name = "users_id")
     private User writer;
 
+    // 위에서 user_id로 User Entity를 참조하는데 아래 두 필드가 테이블에 저장될 필요가 있을까?
     private String username;
 
-    private Long userId;
 
     public SubComment(Long id, Comment comment, String content, Post post, User writer,String username,Long userId){
         this.id = id;
@@ -50,9 +52,5 @@ public class SubComment extends TimeStamped {
         this.post = post;
         this.writer = writer;
         this.username = username;
-        this.userId = userId;
     }
-
-
-
 }

--- a/src/main/java/com/team_7/moment_film/domain/post/entity/Post.java
+++ b/src/main/java/com/team_7/moment_film/domain/post/entity/Post.java
@@ -3,6 +3,7 @@ package com.team_7.moment_film.domain.post.entity;
 import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
+import com.querydsl.core.annotations.QueryProjection;
 import com.team_7.moment_film.domain.comment.entity.Comment;
 import com.team_7.moment_film.domain.comment.entity.SubComment;
 import com.team_7.moment_film.domain.user.entity.User;
@@ -55,6 +56,7 @@ public class Post extends TimeStamped {
 //    @JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "id") // 추가
 //    private List<Comment> children = new ArrayList<>();
 
+    // Count가 DB에 저장되어야 할까?
     @ColumnDefault("0")
     @Column(name = "like_count", nullable = false)
     private Integer likeCount;
@@ -67,14 +69,24 @@ public class Post extends TimeStamped {
     @Column(name = "comment_count",nullable = false)
     private Integer commentCount;
 
-
+    // 게시글 <- 댓글 <- 대댓글
+    // 게시글 <- 대댓글 x
     @Fetch(SUBSELECT)
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Comment> commentList = new ArrayList<>();
-
+    // 대댓글이 Post Entity를 왜 참조해야하는가?
+    // 게시글이 삭제되면 모든 댓글이 삭제되기 때문에 commentList는  orphanRemoval 옵션을 거는것이 맞다.
+    // 하지만 subCommnets는 댓글 Entity에서 orphanRemoval 옵션을 걸어야 하는 것이 아닐까?
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<SubComment> subComments = new ArrayList<>();
 
+    @QueryProjection
+    public Post(Long postId, String contents, String image, String title){
+        this.id = postId;
+        this.contents = contents;
+        this.image = image;
+        this.title = title;
+    }
 
 
     // 이 부분부터 증가 함수들 추가
@@ -108,7 +120,6 @@ public class Post extends TimeStamped {
             for (SubComment subComment : comment.getSubComments()) {
                 SubComment newSubComment = SubComment.builder()
                         .id(subComment.getId())
-                        .userId(user.getId())
                         .username(subComment.getWriter().getUsername())
                         .content(subComment.getContent())
                         .build();

--- a/src/main/java/com/team_7/moment_film/domain/post/entity/TempPost.java
+++ b/src/main/java/com/team_7/moment_film/domain/post/entity/TempPost.java
@@ -1,0 +1,39 @@
+package com.team_7.moment_film.domain.post.entity;
+
+import com.querydsl.core.annotations.QueryProjection;
+import com.team_7.moment_film.domain.user.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class TempPost {
+    private Long id;
+    private String title;
+    private String contents;
+    private String image;
+    private Long userId;
+    private String username;
+
+    @QueryProjection
+    public TempPost(Long id, String title, String contents, String image) {
+        this.id = id;
+        this.title = title;
+        this.contents = contents;
+        this.image = image;
+    }
+
+    @QueryProjection
+    public TempPost(Long id, String title, String contents, String image, User user) {
+        this.id = id;
+        this.title = title;
+        this.contents = contents;
+        this.image = image;
+        this.userId = user.getId();
+        this.username = user.getUsername();
+    }
+}

--- a/src/main/java/com/team_7/moment_film/domain/post/repository/PostQueryRepository.java
+++ b/src/main/java/com/team_7/moment_film/domain/post/repository/PostQueryRepository.java
@@ -1,10 +1,15 @@
 package com.team_7.moment_film.domain.post.repository;
 
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.SubQueryExpression;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import com.team_7.moment_film.domain.post.dto.PostSliceRequest;
+import com.team_7.moment_film.domain.like.entity.QLike;
 import com.team_7.moment_film.domain.post.entity.Post;
+import com.team_7.moment_film.domain.post.entity.TempPost;
+import com.team_7.moment_film.domain.user.entity.QUser;
 import jakarta.annotation.Nullable;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -49,7 +54,36 @@ public class PostQueryRepository {
                 .fetch();
     }
 
+    // 내가 작성한 게시글(필요한 필드만)
+    public List<TempPost> getMyPosts(Long id) {
+        List<TempPost> postList = jpaQueryFactory
+                .select(Projections.constructor(TempPost.class, post.id, post.title, post.contents, post.image))
+                .from(post)
+                .where(post.user.id.eq(id))
+                .orderBy(post.createdAt.desc())
+                .fetch();
+        return  postList;
+    }
 
+    // 내가 좋아요한 게시글(필요한 필드만)
+    public List<TempPost> getLikedPosts(Long userId) {
+        QUser user = QUser.user;
+        QLike like =QLike.like;
+        SubQueryExpression<Long> subquery = JPAExpressions
+                .select(like.post.id)
+                .from(user)
+                .leftJoin(like).on(user.id.eq(like.user.id))
+                .where(user.id.eq(userId));
+
+
+        List<TempPost> likedPostList = jpaQueryFactory
+                .select(Projections.constructor(TempPost.class, post.id, post.title, post.contents, post.image, post.user))
+                .from(post)
+                .where(post.id.in(subquery))
+                .fetch();
+
+        return likedPostList;
+    }
 
 
 

--- a/src/main/java/com/team_7/moment_film/domain/user/dto/ProfileResponseDto.java
+++ b/src/main/java/com/team_7/moment_film/domain/user/dto/ProfileResponseDto.java
@@ -1,6 +1,6 @@
 package com.team_7.moment_film.domain.user.dto;
 
-import com.team_7.moment_film.domain.post.entity.Post;
+import com.team_7.moment_film.domain.post.entity.TempPost;
 import com.team_7.moment_film.domain.user.entity.User;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,7 +14,7 @@ public class ProfileResponseDto {
     private String username;
     private List<User> followerList;
     private List<User> followingList;
-    private List<Post> postList;
+    private List<TempPost> postList;
     private int postListCnt;
-    private List<Post> likePosts;
+    private List<TempPost> likePosts;
 }

--- a/src/main/java/com/team_7/moment_film/domain/user/entity/User.java
+++ b/src/main/java/com/team_7/moment_film/domain/user/entity/User.java
@@ -33,6 +33,9 @@ public class User {
     @Column
     private boolean isKakao;
 
+    @OneToMany(mappedBy = "user")
+    private List<Post> postList;
+
     @Column
     @OneToMany(mappedBy = "follower")
     private List<Follow> followerList;

--- a/src/main/java/com/team_7/moment_film/domain/user/service/UserService.java
+++ b/src/main/java/com/team_7/moment_film/domain/user/service/UserService.java
@@ -1,9 +1,9 @@
 package com.team_7.moment_film.domain.user.service;
 
 import com.team_7.moment_film.domain.follow.entity.Follow;
-import com.team_7.moment_film.domain.like.entity.Like;
 import com.team_7.moment_film.domain.like.repository.LikeRepository;
-import com.team_7.moment_film.domain.post.entity.Post;
+import com.team_7.moment_film.domain.post.entity.TempPost;
+import com.team_7.moment_film.domain.post.repository.PostQueryRepository;
 import com.team_7.moment_film.domain.post.repository.PostRepository;
 import com.team_7.moment_film.domain.user.dto.*;
 import com.team_7.moment_film.domain.user.entity.User;
@@ -17,6 +17,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Slf4j(topic = "User Service")
 @Service
@@ -26,6 +27,7 @@ public class UserService {
     private final PostRepository postRepository;
     private final LikeRepository likeRepository;
     private final PasswordEncoder passwordEncoder;
+    private final PostQueryRepository postQueryRepository;
 
     // 회원가입 비즈니스 로직
     public CustomResponseEntity<String> signup(SignupRequestDto signupRequestDto) {
@@ -62,20 +64,51 @@ public class UserService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 사용자입니다."));
 
-        // 내가 작성한 게시글 리스트
-        List<Post> postList = postRepository.findByUserId(user.getId());
-        List<Post> myPostList = postList.stream().map(post -> Post.builder()
-                .id(post.getId())
-                .image(post.getImage())
-                .build()).toList();
+//         내가 작성한 게시글 리스트 (1번 방법 : userId로 PostRepository에서 게시글 리스트 조회)
+//        List<Post> postList = postRepository.findByUserId(user.getId());
+//        List<Post> myPostList = postList.stream().map(post -> Post.builder()
+//                .id(post.getId())
+//                .title(post.getTitle())
+//                .image(post.getImage())
+//                .contents(post.getContents())
+//                .build()).toList();
 
-        // 좋아요한 게시글 리스트
-        List<Like> likeList = likeRepository.findByUserId(user.getId());
-        List<Post> likePosts = likeList.stream().map(like -> Post.builder()
-                .id(like.getPost().getId())
-                .image(like.getPost().getImage())
-                .username(like.getUser().getUsername())
-                .build()).toList();
+//        내가 작성한 게시글 리스트 (2번 방법 : User Entity에서 양방향 참조로 연관된 PostList를 Getter로 조회) ✨
+//        List<Post> postList = user1.getPostList().stream().map(post -> Post.builder()
+//                .id(post.getId())
+//                .title(post.getTitle())
+//                .contents(post.getContents())
+//                .image(post.getImage())
+//                .build())
+//                .toList();
+
+        // 내가 작성한 게시글 리스트 테스트 (임시 Entity: Post Entity에서 일부 필드만 가져왔을 때 연관된 댓글/대댓글 필드도 다가져와짐)
+        List<TempPost> postList = postQueryRepository.getMyPosts(userId);
+        postList.stream().map(tempPost -> TempPost.builder()
+                .id(tempPost.getId())
+                .title(tempPost.getTitle())
+                .contents(tempPost.getContents())
+                .image(tempPost.getImage())
+                .build())
+                .collect(Collectors.toList());
+
+//         좋아요한 게시글 리스트 (원본)
+//        List<Like> likeList = likeRepository.findByUserId(user.getId());
+//        List<Post> likePosts = likeList.stream().map(like -> Post.builder()
+//                .id(like.getPost().getId())
+//                .image(like.getPost().getImage())
+//                .username(like.getUser().getUsername())
+//                .build()).toList();
+        List<TempPost> likedPostList = postQueryRepository.getLikedPosts(userId);
+        likedPostList.stream().map(tempPost -> TempPost.builder()
+                .id(tempPost.getId())
+                .title(tempPost.getTitle())
+                .contents(tempPost.getContents())
+                .image(tempPost.getImage())
+                .userId(tempPost.getUserId())
+                .username(tempPost.getUsername())
+                .build())
+                .collect(Collectors.toList());
 
 
         // 조회한 유저의 팔로잉 리스트
@@ -99,9 +132,9 @@ public class UserService {
                 .username(user.getUsername())
                 .followerList(followers)
                 .followingList(followings)
-                .postList(myPostList)
-                .postListCnt(myPostList.size())
-                .likePosts(likePosts)
+                .postList(postList)
+                .postListCnt(postList.size())
+                .likePosts(likedPostList)
                 .build();
 
         return CustomResponseEntity.dataResponse(HttpStatus.OK, responseDto);


### PR DESCRIPTION
- 작성한 게시글, 좋아요한 게시글이 존재하는 경우 500 error 발생
- Post와의 연관 관계에서 문제가 있는 것으로 파악
- Post Entity와 하위 연관 관계가 수정될 때 까지 임시로 TempPost 클래스 사용(추후 Post로 변경 예정)
- 현재 프로필 조회 시 모든 데이터 정상적으로 반환됨.