### PR TITLE
fix: comment,subComment,post 전체적인 불필요한 코드 제거

### DIFF
--- a/src/main/java/com/team_7/moment_film/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/team_7/moment_film/domain/comment/controller/CommentController.java
@@ -29,10 +29,4 @@ public class CommentController {
         return commentService.deleteComment(commentId, userDetails);
     }
 
-    //조회
-    @GetMapping
-    public ResponseEntity<ApiResponse> getAllComment(@PathVariable Long postId) {
-        return commentService.getAllComment(postId);
-    }
-
 }

--- a/src/main/java/com/team_7/moment_film/domain/comment/dto/CommentRequestDTO.java
+++ b/src/main/java/com/team_7/moment_film/domain/comment/dto/CommentRequestDTO.java
@@ -1,9 +1,11 @@
 package com.team_7.moment_film.domain.comment.dto;
 
-import com.team_7.moment_film.domain.user.entity.User;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 @AllArgsConstructor
 public class CommentRequestDTO {
     private String content;

--- a/src/main/java/com/team_7/moment_film/domain/comment/dto/CommentResponseDTO.java
+++ b/src/main/java/com/team_7/moment_film/domain/comment/dto/CommentResponseDTO.java
@@ -1,14 +1,12 @@
 package com.team_7.moment_film.domain.comment.dto;
 
 
-import com.team_7.moment_film.domain.user.entity.User;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.io.Serializable;
-import java.util.ArrayList;
 import java.util.List;
 
 @NoArgsConstructor
@@ -17,9 +15,7 @@ import java.util.List;
 @Getter
 public class CommentResponseDTO implements Serializable {
     private Long id;
-    private Long postId;
     private Long userId;
-    private User writer;
     private String username;
     private String content;
     private List<SubCommentResponseDTO> subComments;

--- a/src/main/java/com/team_7/moment_film/domain/comment/dto/SubCommentRequestDTO.java
+++ b/src/main/java/com/team_7/moment_film/domain/comment/dto/SubCommentRequestDTO.java
@@ -1,13 +1,12 @@
 package com.team_7.moment_film.domain.comment.dto;
 
-import com.team_7.moment_film.domain.user.entity.User;
 import jakarta.persistence.Lob;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 @AllArgsConstructor
 public class SubCommentRequestDTO {
     @Lob

--- a/src/main/java/com/team_7/moment_film/domain/comment/dto/SubCommentResponseDTO.java
+++ b/src/main/java/com/team_7/moment_film/domain/comment/dto/SubCommentResponseDTO.java
@@ -1,6 +1,5 @@
 package com.team_7.moment_film.domain.comment.dto;
 
-import jakarta.persistence.Lob;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,11 +12,8 @@ import lombok.NoArgsConstructor;
 public class SubCommentResponseDTO {
     //subcommentId
     private Long id;
-    private Long postId;
-    private Long commentId;
     private Long UserId;
-    @Lob
+    private Long commentId;
     private String content;
     private String username;
-
 }

--- a/src/main/java/com/team_7/moment_film/domain/comment/entity/SubComment.java
+++ b/src/main/java/com/team_7/moment_film/domain/comment/entity/SubComment.java
@@ -1,6 +1,5 @@
 package com.team_7.moment_film.domain.comment.entity;
 
-import com.team_7.moment_film.domain.post.entity.Post;
 import com.team_7.moment_film.domain.user.entity.User;
 import com.team_7.moment_film.global.config.TimeStamped;
 import jakarta.persistence.*;
@@ -29,10 +28,6 @@ public class SubComment extends TimeStamped {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "comment_id")
     private Comment comment;
-
-//    @ManyToOne(fetch = FetchType.LAZY)
-//    @JoinColumn(name = "post_id") // 수정: post_id로 변경
-//    private Post post; // 수정: Post 타입으로 변경
 
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "users_id")

--- a/src/main/java/com/team_7/moment_film/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/team_7/moment_film/domain/comment/repository/CommentRepository.java
@@ -10,5 +10,4 @@ import java.util.List;
 @Repository
 public interface CommentRepository extends JpaRepository<Comment,Long>{
 
-    List<Comment> findAllByPostId(Long postId);
 }

--- a/src/main/java/com/team_7/moment_film/domain/comment/repository/SubCommentRepository.java
+++ b/src/main/java/com/team_7/moment_film/domain/comment/repository/SubCommentRepository.java
@@ -6,6 +6,4 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface SubCommentRepository extends JpaRepository<SubComment, Long> {
-
-    List<SubComment> findAllByCommentId(Long commentId);
 }

--- a/src/main/java/com/team_7/moment_film/domain/comment/service/CommentService.java
+++ b/src/main/java/com/team_7/moment_film/domain/comment/service/CommentService.java
@@ -4,9 +4,7 @@ package com.team_7.moment_film.domain.comment.service;
 import com.team_7.moment_film.domain.comment.dto.CommentRequestDTO;
 import com.team_7.moment_film.domain.comment.dto.CommentResponseDTO;
 import com.team_7.moment_film.domain.comment.entity.Comment;
-import com.team_7.moment_film.domain.comment.entity.SubComment;
 import com.team_7.moment_film.domain.comment.repository.CommentRepository;
-import com.team_7.moment_film.domain.comment.repository.SubCommentRepository;
 import com.team_7.moment_film.domain.post.entity.Post;
 import com.team_7.moment_film.domain.post.repository.PostRepository;
 import com.team_7.moment_film.domain.user.entity.User;
@@ -15,14 +13,9 @@ import com.team_7.moment_film.global.dto.ApiResponse;
 import com.team_7.moment_film.global.security.UserDetailsImpl;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @Service
 @Slf4j
@@ -32,10 +25,6 @@ public class CommentService {
     private final CommentRepository commentRepository;
     private final PostRepository postrepository;
     private final UserRepository userRepository;
-    private final SubCommentRepository subCommentRepository;
-    private static final Logger logger = LoggerFactory.getLogger(CommentService.class);
-
-
     //댓글 작성 메소드
     public ResponseEntity<ApiResponse> createComment(Long postId, CommentRequestDTO requestDTO, UserDetailsImpl userDetails) {
         try {
@@ -62,52 +51,20 @@ public class CommentService {
             ApiResponse apiResponse = ApiResponse.builder().status(HttpStatus.CREATED).data(responseDTO).build();
             return ResponseEntity.status(HttpStatus.CREATED).body(apiResponse);
         } catch (IllegalArgumentException e) {
-            log.error("IllegalArgumentException occurred: {}", e.getMessage(), e);
-            ApiResponse apiResponse = ApiResponse.builder().status(HttpStatus.BAD_REQUEST).msg(e.getMessage()).build();
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(apiResponse);
+            throw new IllegalArgumentException("오류 입니다.!" + e.getMessage() + e);
         } catch (Exception e) {
-            logger.error("An error occurred: " + e.getMessage());
-            ApiResponse apiResponse = ApiResponse.builder().status(HttpStatus.INTERNAL_SERVER_ERROR).msg("서버 오류가 발생했습니다.").build();
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(apiResponse);
+            throw new IllegalArgumentException("서버 오류입니다.!" + e.getMessage() + e);
         }
     }
 
-    //댓글 조회 메서드
-    public ResponseEntity<ApiResponse> getAllComment(Long postId) {
-        Post post = postrepository.findById(postId).orElseThrow(
-                () -> new IllegalArgumentException("존재하지 않은 게시글 입니다.")
-        );
-
-        List<Comment> commentList = commentRepository.findAllByPostId(postId);
-        List<CommentResponseDTO> commentResponseDTOList = new ArrayList<>();
-        for (Comment comment : commentList) {
-            commentResponseDTOList.add(
-                    CommentResponseDTO.builder()
-                            .id(comment.getId())
-                            .postId(comment.getPost().getId())
-                            .content(comment.getContent())
-                            .build()
-            );
-        }
-        ApiResponse apiResponse = ApiResponse.builder().status(HttpStatus.OK).data(commentResponseDTOList).build();
-        return ResponseEntity.ok(apiResponse);
-    }
-
+    // 삭제
     public ResponseEntity<ApiResponse> deleteComment(Long commentId, UserDetailsImpl userDetails) {
         Comment comment = commentRepository.findById(commentId).orElseThrow(
                 () -> new IllegalArgumentException("존재하지 않은 댓글입니다.")
         );
-
-        User user = userRepository.findById(userDetails.getUser().getId()).orElseThrow(
-                () -> new IllegalArgumentException("올바른 사용자가 아닙니다.")
-        );
-        if (!comment.getWriter().getId().equals(user.getId())) {
+        if (!comment.getWriter().getId().equals(userDetails.getUser().getId())) {
             throw new IllegalArgumentException("해당 사용자가 아닙니다.");
         } else {
-            // 댓글에 속한 대댓글들도 삭제
-            List<SubComment> subComments = comment.getSubComments();
-            subComments.forEach(subCommentRepository::delete);
-
             commentRepository.delete(comment);
             ApiResponse apiResponse = ApiResponse.builder().status(HttpStatus.OK).msg("삭제 성공!").build();
             return ResponseEntity.ok(apiResponse);

--- a/src/main/java/com/team_7/moment_film/domain/comment/service/SubCommentService.java
+++ b/src/main/java/com/team_7/moment_film/domain/comment/service/SubCommentService.java
@@ -27,7 +27,6 @@ public class SubCommentService {
 
     private final CommentRepository commentRepository;
     private final SubCommentRepository subCommentRepository;
-    private final UserRepository userRepository;
 
     // 대댓글 생성
     public ResponseEntity<ApiResponse> createSubComment(Long commentId, SubCommentRequestDTO requestDTO, UserDetailsImpl userDetails) {
@@ -54,10 +53,6 @@ public class SubCommentService {
     public ResponseEntity<ApiResponse> deleteSubComment(Long subcommentId, UserDetailsImpl userDetails) {
         SubComment subComment = subCommentRepository.findById(subcommentId).orElseThrow(
                 () -> new IllegalArgumentException("존재하지 않는 대댓글입니다.")
-        );
-
-        User user = userRepository.findById(userDetails.getId()).orElseThrow(
-                () -> new IllegalArgumentException("올바른 사용자가 아닙니다.")
         );
 
         if (!subComment.getWriter().getId().equals(userDetails.getUser().getId())) {

--- a/src/main/java/com/team_7/moment_film/domain/like/repository/LikeRepository.java
+++ b/src/main/java/com/team_7/moment_film/domain/like/repository/LikeRepository.java
@@ -3,12 +3,9 @@ package com.team_7.moment_film.domain.like.repository;
 import com.team_7.moment_film.domain.like.entity.Like;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
 import java.util.Optional;
 
 public interface LikeRepository extends JpaRepository<Like, Long> {
-    List<Like> findByUserId(Long userId);
     Optional<Like> findByUserIdAndPostId(Long userId, Long postId);
     void deleteByUserIdAndPostId(Long userId, Long postId);
-    boolean existsByPostIdAndUserId(Long postId, Long userId);
 }

--- a/src/main/java/com/team_7/moment_film/domain/post/dto/PostSliceResponse.java
+++ b/src/main/java/com/team_7/moment_film/domain/post/dto/PostSliceResponse.java
@@ -7,13 +7,16 @@ public record PostSliceResponse(
         long id,
         String title,
         String image,
-        String username
+        String username,
+        Long viewCount,
+        int likeCount,
+        int commentCount
 
 
 ) {
 
     public static PostSliceResponse from(Post post) {
-        return new PostSliceResponse(post.getId(), post.getTitle(), post.getImage(), post.getUser().getUsername());
+        return new PostSliceResponse(post.getId(), post.getTitle(), post.getImage(), post.getUser().getUsername(), post.getViewCount(), post.getLikeList().size(),post.getCommentList().size());
     }
 
 }

--- a/src/main/java/com/team_7/moment_film/domain/post/repository/PostQueryRepository.java
+++ b/src/main/java/com/team_7/moment_film/domain/post/repository/PostQueryRepository.java
@@ -28,13 +28,13 @@ public class PostQueryRepository {
     //공통
     private JPAQuery<Post> baseQuery(Long id) {
         return jpaQueryFactory.selectFrom(post)
-                .where(ltPostId(id))
-                .orderBy(post.id.desc());
+                .where(ltPostId(id));
     }
 
     //최신순 (무한스크롤)
     public List<Post> getSliceOfPost(@Nullable Long id, int size) {
         return baseQuery(id)
+                .orderBy(post.id.desc())
                 .limit(size)
                 .fetch();
     }

--- a/src/main/java/com/team_7/moment_film/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/team_7/moment_film/domain/post/repository/PostRepository.java
@@ -8,7 +8,6 @@ import java.util.List;
 import java.util.Optional;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
-    List<Post> findByUserId(Long userId);
     @Query("select p from Post p join fetch p.user u where p.id = :postId")
     Optional<Post> getPost(Long postId);
 }

--- a/src/main/java/com/team_7/moment_film/domain/post/service/PostService.java
+++ b/src/main/java/com/team_7/moment_film/domain/post/service/PostService.java
@@ -34,12 +34,10 @@ public class PostService {
     private final UserRepository userRepository;
     private final PostRepository postRepository;
     private final S3Service s3Service;
-    private final CommentRepository commentRepository;
-    private final SubCommentRepository subCommentRepository;
 
 
     // 생성
-    @Transactional
+
     public ResponseEntity<ApiResponse> createPost(PostRequestDto requestDto, MultipartFile image, UserDetailsImpl userDetails) {
         String imageUrl = s3Service.upload(image);
         log.info("file path = {}", imageUrl);
@@ -78,13 +76,6 @@ public class PostService {
         if (!post.getUser().getId().equals(user.getId())) {
             throw new IllegalArgumentException("해당 사용자가 아닙니다.");
         } else {
-            // 게시글 삭제 후 댓글과 대댓글들도 함께 삭제
-            List<Comment> comments = post.getCommentList();
-            for (Comment comment : comments) {
-                List<SubComment> subComments = comment.getSubComments();
-                subComments.forEach(subCommentRepository::delete);
-                commentRepository.delete(comment);
-            }
             String imageurl = post.getImage();
             s3Service.delete(imageurl);
             postRepository.delete(post);
@@ -104,6 +95,7 @@ public class PostService {
         PostResponseDto responseDto = PostResponseDto.builder()
                 .id(postId)
                 .userId(post.getUser().getId())
+                .username(post.getUsername())
                 .title(post.getTitle())
                 .contents(post.getContents())
                 .image(post.getImage())


### PR DESCRIPTION
body: 게시글, 대댓글 연관 관계 대댓글이 게시글을 참조 -> 제거
      게시글 생성 서비스 로직에 @Transactional 제거
      게시글 삭제 시 댓글/대댓글 삭제하는 로직 서비스에서 제거
      CommentController에서 생성 컨트롤러 CommentRequestDTO에 User, postId -> 제거
      Comment 작성 서비스 로직에서  catch문 return 말고 예외처리로 throw
      댓글/대댓글 조회 게시글 상세에서 조회되니 댓글/대댓글 자체 조회 코드 삭제
      댓글 삭제 else문 댓글의 대댓글 삭제 로직 삭제
      LikeRepository에서 필요하지 않은 Jpa 삭제
      전체조회시 viewCount,CommentCount,likeCount response로 데이터 표시