### PR TITLE
fix : CustomAuthenticationEntryPoint 수정

### DIFF
--- a/src/main/java/com/team_7/moment_film/domain/user/service/KakaoService.java
+++ b/src/main/java/com/team_7/moment_film/domain/user/service/KakaoService.java
@@ -7,6 +7,7 @@ import com.team_7.moment_film.domain.user.entity.User;
 import com.team_7.moment_film.domain.user.repository.UserRepository;
 import com.team_7.moment_film.global.dto.ApiResponse;
 import com.team_7.moment_film.global.util.JwtUtil;
+import com.team_7.moment_film.global.util.RedisUtil;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +26,7 @@ import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.net.URI;
+import java.util.Date;
 import java.util.UUID;
 
 @Slf4j(topic = "Kakao Service")
@@ -35,6 +37,7 @@ public class KakaoService {
     private final UserRepository userRepository;
     private final RestTemplate restTemplate;
     private final JwtUtil jwtUtil;
+    private final RedisUtil redisUtil;
 
     @Value("${kakao.restapi.key}")
     private String restApiKey;
@@ -71,6 +74,12 @@ public class KakaoService {
 
         log.info("JWT 발급 : accessToken = " + accessToken);
         log.info("JWT 발급 : refreshToken = " + refreshToken);
+
+        String refreshTokenValue = jwtUtil.substringToken(refreshToken);
+        Date expiration = jwtUtil.getUserInfoFromToken(refreshTokenValue).getExpiration();
+
+        redisUtil.setData(username, refreshTokenValue, expiration);
+        log.info("Redis에 RefreshToken 저장(카카오)");
 
         response.setHeader("accessToken", accessToken);
         response.setHeader("refreshToken", refreshToken);

--- a/src/main/java/com/team_7/moment_film/global/exception/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/team_7/moment_film/global/exception/CustomAuthenticationEntryPoint.java
@@ -1,21 +1,68 @@
 package com.team_7.moment_film.global.exception;
 
-import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
 
 @Component
 public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    private final AntPathMatcher antPathMatcher = new AntPathMatcher();
+
     @Override
-    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
+        String requestUri = request.getRequestURI();
+        String errorMessage;
+
+        if (isSupportedUri(requestUri)) {
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            errorMessage = "로그인이 필요합니다.";
+        } else {
+            response.setStatus(HttpServletResponse.SC_NOT_FOUND);
+            errorMessage = "존재하지 않는 URL입니다.";
+        }
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");
-        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-        response.getWriter().write("로그인이 필요합니다.");
+        response.getWriter().write(errorMessage);
+    }
+
+    // 클라이언트가 접근한 uri가 서버에서 제공하는 uri인지 확인하는 메서드
+    private boolean isSupportedUri(String requestUri) {
+        List<String> supportedUri = Arrays.asList(
+                "/api/user/signup", // 회원가입
+                "/api/user/withdrawal", // 회원탈퇴
+                "/api/user/login", // 로그인
+                "/api/user/logout", // 로그아웃
+                "/api/user/kakao/callback", // 카카오 로그인
+                "/api/user/google/callback", // 구글 로그인
+                "/api/user/search", // 사용자 검색
+                "/api/user/popular", // 인기 사용자 조회
+                "/api/follow/{userId}", // 사용자 팔로우
+                "/api/user/profile/{userId}", // 사용자 프로필 조회
+                "/api/user/info", // 사용자 개인정보 조회
+                "/api/user/password-reset", // 비밀번호 변경
+                "/api/user/email", // 비밀번호 인증 코드 메일 전송
+                "/api/post", // 게시글 조회
+                "/api/post/like", // 게시글 좋아요순 조회
+                "/api/post/view", // 게시글 조회순 조회
+                "/api/post/{postId}", // 게시글 상세 조회
+                "/api/post/{postId}/likes", //게시글 좋아요/취소
+                "/api/post/{postId}/comment", // 댓글 작성
+                "/api/post/{postId}/comment/{commentId}", // 댓글 삭제
+                "/api/post/{postId}/comment/{commentId}/subcomment", // 대댓글 작성
+                "/api/post/{postId}/comment/{commentId}/subcomment/{subcommentId}", // 대댓글 삭제
+                "/api/filter", // 필터 등록, 내가 만든 필터 조회
+                "/api/filter/{filterId}", // 특정 필터 적용
+                "/api/frame", // 프레임 등록, 내가 만든 프레임 조회
+                "/api/frame/{frameId}" // 특정 프레임 적용
+        );
+
+        return supportedUri.stream().anyMatch(urlPattern -> antPathMatcher.match(urlPattern, requestUri));
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -23,3 +23,5 @@ spring.h2.console.path=/h2-console
 mybatis.mapper-locations=classpath:/mapper/*.xml
 spring.servlet.multipart.maxFileSize=2MB
 spring.servlet.multipart.maxRequestSize=5MB
+
+spring.mail.host=smtp.naver.com


### PR DESCRIPTION
- 기존 : 클라이언트가 서버에서 제공하지 않는 URI로 접근하거나, 인증이 필요한 URI에 미인증 상태로 접근 시 
status : 401 UNAUTHORIZED, msg : "로그인이 필요합니다" response 전달.

#### 변경 : 기존에 예외 처리하던 두 경우를 분리하여 예외 처리
- 서버에서 제공하지 않는 URI로 접근 시 404 NOT_FOUND, "존재하지 않는 URL입니다.
- 인증이 필요한 URI에 미인증 상태로 접근 시 401 UNAUTHORIZED,"로그인이 필요합니다"