### PR TITLE
Fix : 회원 탈퇴 에러 수정

### DIFF
--- a/src/main/java/com/team_7/moment_film/domain/comment/entity/Comment.java
+++ b/src/main/java/com/team_7/moment_film/domain/comment/entity/Comment.java
@@ -15,12 +15,11 @@ import static jakarta.persistence.FetchType.LAZY;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-@Table(name = "comments")
+@Table(name = "comment")
 public class Comment extends TimeStamped {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "comment_id")
     private Long id;
 
     @Column(nullable = false)
@@ -33,10 +32,9 @@ public class Comment extends TimeStamped {
     private Post post;
 
     @ManyToOne(fetch = LAZY)
-    @JoinColumn(name = "users_id")
+    @JoinColumn(name = "user_id")
     private User writer;
 
-    @OneToMany(mappedBy = "comment", cascade = CascadeType.REMOVE, fetch = LAZY)
+    @OneToMany(mappedBy = "comment", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<SubComment> subComments;
-
 }

--- a/src/main/java/com/team_7/moment_film/domain/comment/entity/SubComment.java
+++ b/src/main/java/com/team_7/moment_film/domain/comment/entity/SubComment.java
@@ -8,8 +8,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import static jakarta.persistence.FetchType.LAZY;
-
 
 @NoArgsConstructor
 @Builder
@@ -29,8 +27,7 @@ public class SubComment extends TimeStamped {
     @JoinColumn(name = "comment_id")
     private Comment comment;
 
-    @ManyToOne(fetch = LAZY)
-    @JoinColumn(name = "users_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
     private User writer;
-
 }

--- a/src/main/java/com/team_7/moment_film/domain/customfilter/entity/Filter.java
+++ b/src/main/java/com/team_7/moment_film/domain/customfilter/entity/Filter.java
@@ -7,6 +7,8 @@ import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 import java.util.List;
 
@@ -29,12 +31,13 @@ public class Filter {
 
     @ManyToOne
     @JoinColumn(name = "user_id")
+    @OnDelete(action = OnDeleteAction.SET_NULL)
     private User user;
 
     @OneToMany(mappedBy = "filter")
     private List<Post> postList;
 
-    public Filter(FilterRequestDto requestDto, User user){
+    public Filter(FilterRequestDto requestDto, User user) {
         this.filterName = requestDto.getFilterName();
         this.blur = requestDto.getBlur();
         this.brightness = requestDto.getBrightness();

--- a/src/main/java/com/team_7/moment_film/domain/customframe/entity/Frame.java
+++ b/src/main/java/com/team_7/moment_film/domain/customframe/entity/Frame.java
@@ -7,6 +7,8 @@ import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 import java.util.List;
 
@@ -33,6 +35,7 @@ public class Frame {
 
     @ManyToOne
     @JoinColumn(name = "user_id")
+    @OnDelete(action = OnDeleteAction.SET_NULL)
     private User user;
 
     @OneToMany(mappedBy = "frame")

--- a/src/main/java/com/team_7/moment_film/domain/follow/entity/Follow.java
+++ b/src/main/java/com/team_7/moment_film/domain/follow/entity/Follow.java
@@ -14,7 +14,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class Follow {
     @Id
-    @Column(name = "follow_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 

--- a/src/main/java/com/team_7/moment_film/domain/like/entity/Like.java
+++ b/src/main/java/com/team_7/moment_film/domain/like/entity/Like.java
@@ -18,7 +18,6 @@ public class Like {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "likes_id")
     private Long id;
 
     @ManyToOne

--- a/src/main/java/com/team_7/moment_film/domain/post/entity/Post.java
+++ b/src/main/java/com/team_7/moment_film/domain/post/entity/Post.java
@@ -15,6 +15,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -61,12 +63,11 @@ public class Post extends TimeStamped {
     private Long userId;
 
     @Builder.Default
-    @OneToMany(mappedBy = "post", cascade = CascadeType.REMOVE)
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Comment> commentList = new ArrayList<>();
 
-
     @Builder.Default
-    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Like> likeList = new ArrayList<>();
 
     @Column(name = "viewCount")

--- a/src/main/java/com/team_7/moment_film/domain/user/entity/User.java
+++ b/src/main/java/com/team_7/moment_film/domain/user/entity/User.java
@@ -1,7 +1,8 @@
 package com.team_7.moment_film.domain.user.entity;
 
+import com.team_7.moment_film.domain.customfilter.entity.FilterBookMark;
+import com.team_7.moment_film.domain.customframe.entity.FrameBookMark;
 import com.team_7.moment_film.domain.follow.entity.Follow;
-import com.team_7.moment_film.domain.like.entity.Like;
 import com.team_7.moment_film.domain.post.entity.Post;
 import jakarta.persistence.*;
 import lombok.*;
@@ -33,14 +34,20 @@ public class User {
     @Column
     private String provider;
 
-    @OneToMany(mappedBy = "user")
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Post> postList;
 
     @Column
-    @OneToMany(mappedBy = "follower")
+    @OneToMany(mappedBy = "follower", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Follow> followerList;
 
     @Column
-    @OneToMany(mappedBy = "following")
+    @OneToMany(mappedBy = "following", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Follow> followingList;
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<FilterBookMark> filterBookMarkList;
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<FrameBookMark> frameBookMarkList;
 }

--- a/src/main/java/com/team_7/moment_film/domain/user/service/UserService.java
+++ b/src/main/java/com/team_7/moment_film/domain/user/service/UserService.java
@@ -20,6 +20,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
 import java.security.GeneralSecurityException;
@@ -203,6 +204,7 @@ public class UserService {
     }
 
     // 회원탈퇴
+    @Transactional
     public ResponseEntity<ApiResponse> withdrawal(User user, String accessToken) {
         String username = user.getUsername();
         if (user.getProvider().equals("google")) {


### PR DESCRIPTION
- 탈퇴하려는 유저가 게시글, 댓글, 대댓글, 필터, 프레임 등 다른 Entity를 생성했을 경우 탈퇴가 되지 않는 에러 해결.
- 필터와 프레임은 회원 탈퇴 후에도 유지되야하기 때문에 User 필드를 Null로 변경되도록 수정
- 원인은 테이블 생성 시점과 회원탈퇴 시점의 제약 조건 차이로 확인
- 일부 테이블의 컬럼 id 값 변경 복수 -> 단수