### PR TITLE
fix : 회원 탈퇴 에러 수정 (댓글, 대댓글 작성한 유저 탈퇴 시 에러)

### DIFF
--- a/src/main/java/com/team_7/moment_film/domain/comment/entity/Comment.java
+++ b/src/main/java/com/team_7/moment_film/domain/comment/entity/Comment.java
@@ -5,10 +5,10 @@ import com.team_7.moment_film.domain.user.entity.User;
 import com.team_7.moment_film.global.config.TimeStamped;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 import java.util.List;
-
-import static jakarta.persistence.FetchType.LAZY;
 
 @Entity
 @Getter
@@ -27,12 +27,13 @@ public class Comment extends TimeStamped {
     @Lob
     private String content;
 
-    @ManyToOne(fetch = LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id")
     private Post post;
 
-    @ManyToOne(fetch = LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private User writer;
 
     @OneToMany(mappedBy = "comment", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/src/main/java/com/team_7/moment_film/domain/comment/entity/SubComment.java
+++ b/src/main/java/com/team_7/moment_film/domain/comment/entity/SubComment.java
@@ -7,6 +7,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 
 @NoArgsConstructor
@@ -25,9 +27,11 @@ public class SubComment extends TimeStamped {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "comment_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Comment comment;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private User writer;
 }

--- a/src/main/java/com/team_7/moment_film/domain/customfilter/entity/FilterBookMark.java
+++ b/src/main/java/com/team_7/moment_film/domain/customfilter/entity/FilterBookMark.java
@@ -6,6 +6,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @Getter
@@ -19,6 +21,7 @@ public class FilterBookMark {
 
     @ManyToOne
     @JoinColumn(name = "user_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private User user;
 
     @ManyToOne

--- a/src/main/java/com/team_7/moment_film/domain/customframe/entity/FrameBookMark.java
+++ b/src/main/java/com/team_7/moment_film/domain/customframe/entity/FrameBookMark.java
@@ -6,6 +6,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @Getter
@@ -19,6 +21,7 @@ public class FrameBookMark {
 
     @ManyToOne
     @JoinColumn(name = "user_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private User user;
 
     @ManyToOne

--- a/src/main/java/com/team_7/moment_film/domain/follow/entity/Follow.java
+++ b/src/main/java/com/team_7/moment_film/domain/follow/entity/Follow.java
@@ -6,6 +6,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @Getter
@@ -19,10 +21,12 @@ public class Follow {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "follower_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private User follower;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "following_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private User following;
 
 }

--- a/src/main/java/com/team_7/moment_film/domain/follow/repository/FollowRepository.java
+++ b/src/main/java/com/team_7/moment_film/domain/follow/repository/FollowRepository.java
@@ -3,7 +3,11 @@ package com.team_7.moment_film.domain.follow.repository;
 import com.team_7.moment_film.domain.follow.entity.Follow;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface FollowRepository extends JpaRepository<Follow,Long> {
+    List<Follow> findAllByFollowerId(Long UserId); // 팔로잉 리스트
+    List<Follow> findAllByFollowingId(Long UserId); // 팔로워 리스트
     boolean existsByFollowerIdAndFollowingId(Long followerId, Long followingId);
 
     void deleteByFollowerIdAndFollowingId(Long followerId, Long followingId);

--- a/src/main/java/com/team_7/moment_film/domain/like/entity/Like.java
+++ b/src/main/java/com/team_7/moment_film/domain/like/entity/Like.java
@@ -8,6 +8,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Getter
 @NoArgsConstructor
@@ -22,6 +24,7 @@ public class Like {
 
     @ManyToOne
     @JoinColumn(name = "user_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private User user;
 
     @ManyToOne

--- a/src/main/java/com/team_7/moment_film/domain/post/entity/Post.java
+++ b/src/main/java/com/team_7/moment_film/domain/post/entity/Post.java
@@ -56,6 +56,7 @@ public class Post extends TimeStamped {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     @JsonIgnore
     private User user;
 

--- a/src/main/java/com/team_7/moment_film/domain/user/entity/User.java
+++ b/src/main/java/com/team_7/moment_film/domain/user/entity/User.java
@@ -1,13 +1,7 @@
 package com.team_7.moment_film.domain.user.entity;
 
-import com.team_7.moment_film.domain.customfilter.entity.FilterBookMark;
-import com.team_7.moment_film.domain.customframe.entity.FrameBookMark;
-import com.team_7.moment_film.domain.follow.entity.Follow;
-import com.team_7.moment_film.domain.post.entity.Post;
 import jakarta.persistence.*;
 import lombok.*;
-
-import java.util.List;
 
 @Builder
 @Getter
@@ -31,23 +25,6 @@ public class User {
     @Column(unique = true)
     private String phone;
 
-    @Column
+    @Column(nullable = false)
     private String provider;
-
-    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Post> postList;
-
-    @Column
-    @OneToMany(mappedBy = "follower", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Follow> followerList;
-
-    @Column
-    @OneToMany(mappedBy = "following", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Follow> followingList;
-
-    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<FilterBookMark> filterBookMarkList;
-
-    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<FrameBookMark> frameBookMarkList;
 }

--- a/src/main/java/com/team_7/moment_film/domain/user/service/UserService.java
+++ b/src/main/java/com/team_7/moment_film/domain/user/service/UserService.java
@@ -1,6 +1,7 @@
 package com.team_7.moment_film.domain.user.service;
 
 import com.team_7.moment_film.domain.follow.entity.Follow;
+import com.team_7.moment_film.domain.follow.repository.FollowRepository;
 import com.team_7.moment_film.domain.post.entity.Post;
 import com.team_7.moment_film.domain.post.repository.PostQueryRepository;
 import com.team_7.moment_film.domain.user.dto.ProfileResponseDto;
@@ -20,7 +21,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
 import java.security.GeneralSecurityException;
@@ -34,6 +34,7 @@ public class UserService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final PostQueryRepository postQueryRepository;
+    private final FollowRepository followRepository;
     private final RedisUtil redisUtil;
     private final JwtUtil jwtUtil;
     private final EncryptUtil encryptUtil;
@@ -102,14 +103,14 @@ public class UserService {
                 .build()).toList();
 
         // 조회한 유저의 팔로잉 리스트
-        List<Follow> followingList = user.getFollowerList();
+        List<Follow> followingList = followRepository.findAllByFollowerId(user.getId());
         List<User> followings = followingList.stream().map(follow -> User.builder()
                 .id(follow.getFollowing().getId())
                 .username(follow.getFollowing().getUsername())
                 .build()).toList();
 
         // 조회한 유저의 팔로워 리스트
-        List<Follow> followerList = user.getFollowingList();
+        List<Follow> followerList = followRepository.findAllByFollowingId(user.getId());
         List<User> followers = followerList.stream().map(follow -> User.builder()
                 .id(follow.getFollower().getId())
                 .username(follow.getFollower().getUsername())
@@ -204,7 +205,7 @@ public class UserService {
     }
 
     // 회원탈퇴
-    @Transactional
+//    @Transactional
     public ResponseEntity<ApiResponse> withdrawal(User user, String accessToken) {
         String username = user.getUsername();
         if (user.getProvider().equals("google")) {


### PR DESCRIPTION
- 다른 유저가 작성한 게시글에 해당 유저가 댓글 및 대댓글 작성 후 탈퇴 시 에러 발생
- FK 참조 필드에 OnDelete(action = OnDeleteAction.CASCADE)을 적용하여 해당 유저가 삭제 될 때 영속성을 전이하여 같이 삭제되도록 설정
- User의 양방향 참조 관계 모두 해제 후 외래키 주인의 컬럼에 @OnDelete 적용