### PR TITLE
fix: user엔티티 resized image 필드 추가

### DIFF
--- a/src/main/java/com/team_7/moment_film/domain/post/dto/PostSliceResponse.java
+++ b/src/main/java/com/team_7/moment_film/domain/post/dto/PostSliceResponse.java
@@ -17,7 +17,7 @@ public record PostSliceResponse(
 ) {
 
     public static PostSliceResponse from(Post post) {
-        return new PostSliceResponse(post.getId(), post.getTitle(), post.getImage(), post.getUser().getUsername(),post.getUser().getImage() ,post.getViewCount(), post.getLikeList().size(),post.getCommentList().size());
+        return new PostSliceResponse(post.getId(), post.getTitle(), post.getImage(), post.getUser().getUsername(),post.getUser().getResizedImage() ,post.getViewCount(), post.getLikeList().size(),post.getCommentList().size());
     }
 
 }

--- a/src/main/java/com/team_7/moment_film/domain/post/entity/Post.java
+++ b/src/main/java/com/team_7/moment_film/domain/post/entity/Post.java
@@ -3,7 +3,6 @@ package com.team_7.moment_film.domain.post.entity;
 import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
-import com.querydsl.core.annotations.QueryProjection;
 import com.team_7.moment_film.domain.comment.entity.Comment;
 import com.team_7.moment_film.domain.customfilter.entity.Filter;
 import com.team_7.moment_film.domain.customframe.entity.Frame;
@@ -63,6 +62,9 @@ public class Post extends TimeStamped {
     @Transient
     private Long userId;
 
+    @Transient
+    private String userImage;
+
     @Builder.Default
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Comment> commentList = new ArrayList<>();
@@ -79,13 +81,13 @@ public class Post extends TimeStamped {
         this.viewCount++;
     }
 
-    @QueryProjection
-    public Post(Long id, String title, String contents, String image, Long userId, String username) {
+    public Post(Long id, String title, String contents, String image, Long userId, String username, String userImage) {
         this.id = id;
         this.title = title;
         this.contents = contents;
         this.image = image;
         this.userId = userId;
         this.username = username;
+        this.userImage = userImage;
     }
 }

--- a/src/main/java/com/team_7/moment_film/domain/post/repository/PostQueryRepository.java
+++ b/src/main/java/com/team_7/moment_film/domain/post/repository/PostQueryRepository.java
@@ -67,7 +67,7 @@ public class PostQueryRepository {
     // 내가 작성한 게시글
     public List<Post> getMyPosts(Long id) {
         List<Post> postList = jpaQueryFactory
-                .select(Projections.constructor(Post.class, post.id, post.title, post.contents, post.image, post.user.id, post.username))
+                .select(Projections.constructor(Post.class, post.id, post.title, post.contents, post.image, post.user.id, post.username, post.user.resizedImage))
                 .from(post)
                 .where(post.user.id.eq(id))
                 .orderBy(post.createdAt.desc())
@@ -86,7 +86,7 @@ public class PostQueryRepository {
                 .where(user.id.eq(userId));
 
         List<Post> likedPostList = jpaQueryFactory
-                .select(Projections.constructor(Post.class, post.id, post.title, post.contents, post.image, post.user.id, post.username))
+                .select(Projections.constructor(Post.class, post.id, post.title, post.contents, post.image, post.user.id, post.username, post.user.resizedImage))
                 .from(post)
                 .where(post.id.in(subquery))
                 .fetch();

--- a/src/main/java/com/team_7/moment_film/domain/post/service/PostService.java
+++ b/src/main/java/com/team_7/moment_film/domain/post/service/PostService.java
@@ -83,7 +83,7 @@ public class PostService {
                 .id(savepost.getId())
                 .title(savepost.getTitle())
                 .contents(savepost.getContents())
-                .image(s3Service.generateOriginalImageUrl(savepost.getImage()))
+                .image(s3Service.generateOriginalImageUrl(savepost.getImage(),POST))
                 .username(savepost.getUser().getUsername())
                 .filterId(savepost.getFilter().getId())
                 .frameId(savepost.getFrame().getId())
@@ -145,12 +145,12 @@ public class PostService {
                 .username(post.getUsername())
                 .title(post.getTitle())
                 .contents(post.getContents())
-                .image(s3Service.generateOriginalImageUrl(post.getImage()))
+                .image(s3Service.generateOriginalImageUrl(post.getImage(),POST))
                 .likeCount(post.getLikeList().size())
                 .viewCount(post.getViewCount())
                 .commentCount(post.getCommentList().size())
                 .likeUserId(likeUser)
-                .userImage(post.getUser().getImage())
+                .userImage(post.getUser().getResizedImage())
                 .frameId(post.getFrame().getId())
                 .frameName(post.getFrame().getFrameName())
                 .filterId(post.getFilter().getId())
@@ -177,7 +177,7 @@ public class PostService {
                     .content(comment.getContent())
                     .username(comment.getWriter().getUsername())
                     .userId(comment.getWriter().getId())
-                    .userImage(comment.getWriter().getImage())
+                    .userImage(comment.getWriter().getResizedImage())
                     .createdAt(comment.getCreatedAtFormatted())
                     .build();
             List<SubCommentResponseDTO> newSubComments = new ArrayList<>();
@@ -187,7 +187,7 @@ public class PostService {
                         .content(subComment.getContent())
                         .username(subComment.getWriter().getUsername())
                         .UserId(subComment.getWriter().getId())
-                        .userImage(subComment.getWriter().getImage())
+                        .userImage(subComment.getWriter().getResizedImage())
                         .createdAt(subComment.getCreatedAtFormatted())
                         .build();
                 newSubComments.add(newSubComment);

--- a/src/main/java/com/team_7/moment_film/domain/post/service/S3Service.java
+++ b/src/main/java/com/team_7/moment_film/domain/post/service/S3Service.java
@@ -21,7 +21,7 @@ import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 
-import static com.team_7.moment_film.global.dto.S3Prefix.POST;
+import static com.team_7.moment_film.global.dto.S3Prefix.FRAME;
 
 @Slf4j
 @Service
@@ -50,10 +50,10 @@ public class S3Service {
             String imageUrl = generateUnsignedUrl(fileName);
             String resizedImageUrl = generateResizedImageUrl(fileName);
             log.info("이미지 업로드 완료: " + imageUrl);
-            if (S3Prefix.equals(POST)) {
-                return resizedImageUrl;
+            if (S3Prefix.equals(FRAME)) {
+                return imageUrl;
             }
-            return imageUrl;
+            return resizedImageUrl;
         } catch (IOException e) {
             throw new UploadException(ErrorCodeEnum.UPLOAD_FAIL, e);
         }
@@ -174,14 +174,19 @@ public class S3Service {
      * @param resizedImageUrl 리사이징 이미지 URL
      * @return 원본 이미지 URL
      */
-    public String generateOriginalImageUrl(String resizedImageUrl) {
+    public String generateOriginalImageUrl(String resizedImageUrl, S3Prefix s3Prefix) {
+        if (resizedImageUrl == null) {
+            return null;
+        }
         String[] parts = resizedImageUrl.split("/");
         String uri = parts[2];
         String objectKey = parts[4];
 
         String originalUri = uri.replace("-resized", "");
 
-        return "https://" + originalUri + "/post/" + objectKey;
+        return "https://" + originalUri + "/" + s3Prefix.getDirectory() + objectKey;
     }
+
+
 
 }

--- a/src/main/java/com/team_7/moment_film/domain/user/entity/User.java
+++ b/src/main/java/com/team_7/moment_film/domain/user/entity/User.java
@@ -37,6 +37,9 @@ public class User {
     @Column
     private String image;
 
+    @Column
+    private String resizedImage;
+
     public void setPoint(Long point) {
         this.point = point;
     }

--- a/src/main/java/com/team_7/moment_film/domain/user/service/UserService.java
+++ b/src/main/java/com/team_7/moment_film/domain/user/service/UserService.java
@@ -101,6 +101,7 @@ public class UserService {
                 .image(post.getImage())
                 .userId(post.getUserId())
                 .username(post.getUsername())
+                .userImage(post.getUserImage())
                 .build()).toList();
 
         // 내가 좋아요한 게시글 리스트
@@ -112,6 +113,7 @@ public class UserService {
                 .image(post.getImage())
                 .userId(post.getUserId())
                 .username(post.getUsername())
+                .userImage(post.getUserImage())
                 .build()).toList();
 
         // 조회한 유저의 팔로잉 리스트
@@ -215,7 +217,8 @@ public class UserService {
                 .password(user.getPassword())
                 .provider(user.getProvider())
                 .point(user.getPoint())
-                .image(imageUrl)
+                .image(s3Service.generateOriginalImageUrl(imageUrl, PROFILE))
+                .resizedImage(imageUrl)
                 .build();
 
         userRepository.save(updateUser);

--- a/src/test/java/com/team_7/moment_film/domain/post/service/PostServiceTest.java
+++ b/src/test/java/com/team_7/moment_film/domain/post/service/PostServiceTest.java
@@ -70,7 +70,7 @@ class PostServiceTest {
 
         // 예상 동작 검증
         verify(postRepository, times(1)).save(any());
-        verify(s3Service, times(1)).generateOriginalImageUrl(any());
+        verify(s3Service, times(1)).generateOriginalImageUrl(any(), any());
 
 
     }


### PR DESCRIPTION
유저 profile image 원본, 리사이징 이미지 url 분리해서 반환

개인정보 수정 시 원본, 리사이징 이미지 둘 다 저장

Image(original) : user 검색, 팔로워 순 user 조회, 프로필 조회, 개인정보 조회
resizedImage : post 전체 조회, 상세 조회, 댓글, 대댓글, 프로필 조회 - 게시글 리스트